### PR TITLE
Start work adding M0+

### DIFF
--- a/src/hal/cortex_m0plus/default_handlers.S
+++ b/src/hal/cortex_m0plus/default_handlers.S
@@ -1,0 +1,57 @@
+/*
+  Zinc, the bare metal stack for rust.
+ Copyright 2014 Vladimir "farcaller" Pouzanov <farcaller@gmail.com>
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+.syntax unified
+.cpu cortex-m0plus
+.arch armv6-m
+.text
+
+#define THUMB_FUNC(NAME) \
+.section .text.isr.##NAME; \
+.align 2; \
+.global NAME; \
+.thumb; \
+.thumb_func; \
+.weak NAME; \
+.type NAME, %function; \
+NAME:
+
+THUMB_FUNC(isr_nmi)
+  bkpt
+
+
+THUMB_FUNC(isr_hardfault)
+  mrs r0, psp
+  mrs r1, msp
+  ldr r2, [r0, 0x18]
+  ldr r3, [r1, 0x18]
+  bkpt
+
+
+THUMB_FUNC(isr_svcall)
+  bkpt
+
+
+THUMB_FUNC(isr_pendsv)
+  bkpt
+
+
+THUMB_FUNC(isr_systick)
+  bkpt
+
+THUMB_FUNC(isr_hang)
+  b isr_hang

--- a/src/hal/cortex_m0plus/isr.rs
+++ b/src/hal/cortex_m0plus/isr.rs
@@ -1,0 +1,51 @@
+// Zinc, the bare metal stack for rust.
+// Copyright 2014 Vladimir "farcaller" Pouzanov <farcaller@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::option::*;
+
+extern {
+  fn __STACK_BASE();
+  fn main();
+  fn _boot_checksum();
+
+  fn isr_nmi();
+  fn isr_hardfault();
+  fn isr_svcall();
+  fn isr_pendsv();
+  fn isr_systick();
+}
+
+static ISRCount: uint = 16;
+
+#[link_section=".isr_vector"]
+#[no_mangle]
+pub static ISRVectors: [Option<extern unsafe fn()>, ..ISRCount] = [
+  Some(__STACK_BASE),
+  Some(main),             // Reset
+  Some(isr_nmi),          // NMI
+  Some(isr_hardfault),    // Hard Fault
+  None,                   // Reserved
+  None,                   // Reserved
+  None,                   // Reserved
+  Some(_boot_checksum),   // NXP Checksum code
+  None,                   // Reserved
+  None,                   // Reserved
+  None,                   // Reserved
+  Some(isr_svcall),       // SVCall
+  None,                   // Reserved for debug
+  None,                   // Reserved
+  Some(isr_pendsv),       // PendSV
+  Some(isr_systick),      // SysTick
+];

--- a/src/hal/cortex_m0plus/mod.rs
+++ b/src/hal/cortex_m0plus/mod.rs
@@ -1,0 +1,16 @@
+// Zinc, the bare metal stack for rust.
+// Copyright 2014 Vladimir "farcaller" Pouzanov <farcaller@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub mod systick;

--- a/src/hal/cortex_m0plus/systick.rs
+++ b/src/hal/cortex_m0plus/systick.rs
@@ -1,0 +1,59 @@
+// Zinc, the bare metal stack for rust.
+// Copyright 2014 Vladimir "farcaller" Pouzanov <farcaller@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Interface to SysTick timer.
+
+#[path="../../lib/ioreg.rs"] mod ioreg;
+
+pub static CALIBRATED: u32 = 0xffffffff;
+
+pub fn setup(calibration: u32, enable_irq: bool) {
+  reg::SysTick.set_control(0b100);  // disabled, no interrupt
+  let reload_val: u32 = match calibration {
+    CALIBRATED => reg::SysTick.calibration() & 0xffffff,
+    val => val,
+  };
+  reg::SysTick.set_reload(reload_val);
+  reg::SysTick.set_current(0);
+  if enable_irq {
+    reg::SysTick.set_control(0b110);
+  }
+}
+
+pub fn enable() {
+  reg::SysTick.set_control(reg::SysTick.control() | 1);
+}
+
+pub fn enable_irq() {
+  reg::SysTick.set_control(reg::SysTick.control() | 0b010);
+}
+
+pub fn disable_irq() {
+  reg::SysTick.set_control(reg::SysTick.control() & !0b010);
+}
+
+mod reg {
+  use lib::volatile_cell::VolatileCell;
+
+  ioreg!(SysTickReg: control, reload, current, calibration)
+  reg_rw!(SysTickReg, control,     set_control, control)
+  reg_rw!(SysTickReg, reload,      set_reload,  reload)
+  reg_rw!(SysTickReg, current,     set_current, current)
+  reg_r!( SysTickReg, calibration,              calibration)
+
+  extern {
+    #[link_name="iomem_SYSTICK"] pub static SysTick: SysTickReg;
+  }
+}


### PR DESCRIPTION
This isn't finished (not included in Rakefile and not used anywhere), but hoping to "dibs" it by throwing a pull request in. I've been working on my own rust/cortex library, but after this came out I figured I'd jump ship.

I've not included the multitasking files (sched.*) as I wasn't able to find the best way to push regs r4-r11 to the stack. The M0+ only allows r4-r7 for an STM/LDM/PUSH/POP and STMDB isn't available.
