### PR TITLE
Remove extra line from lpc/iomem

### DIFF
--- a/src/hal/lpc17xx/iomem.ld
+++ b/src/hal/lpc17xx/iomem.ld
@@ -1,6 +1,5 @@
 INCLUDE ./src/hal/cortex_m3/armmem.ld
 
-PROVIDE(isr_nmi           = isr_default_fault);
 PROVIDE(isr_wdt           = isr_default_fault);
 PROVIDE(isr_timer_0       = isr_default_fault);
 PROVIDE(isr_timer_1       = isr_default_fault);


### PR DESCRIPTION
I left my template line in when I updated the lpc iomem file.
