### PR TITLE
Initial support for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+before_install:
+    - yes | sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded
+    - sudo apt-get update
+install:
+    - sudo apt-get install gcc-arm-none-eabi
+    - curl http://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz | tar xz
+    - gem install pry
+    - mkdir thirdparty
+    - cd thirdparty
+    - curl http://static.rust-lang.org/dist/rust-nightly.tar.gz | tar xz
+    - mv rust-nightly rust
+    - cd rust/src
+    - patch -p1 -i ../../../support/rust.patch
+    - cd ../../..
+before_script:
+    - export TOOLCHAIN_LIBS_PATH=/usr/lib/gcc/arm-none-eabi/4.8.3/
+    - export RUSTC="`pwd`/rust-nightly-x86_64-unknown-linux-gnu/bin/rustc"
+script:
+    - rake PLATFORM=lpc17xx APP=app_blink


### PR DESCRIPTION
Here is some initial support for travis.

It doesn't build successfully at the moment (https://travis-ci.org/bharrisau/zinc/), `support/rake.rb` is pulling the newest master to build libstd which is incompatible with the current rust-nightly in the ppa repository. Looks like f128 was added to the git repo but hasn't appeared in the nightly build.

Not sure of the best solution, one option is to:
- Extract the commit SHA from `rustc --version`
- Clone mozilla/rust with depth ~100
- Checkout the correct SHA before patching
