### PR TITLE
[WIP] Basic 802.15.4 driver code based on mrf24j40

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ TOOLCHAIN = 'arm-none-eabi-'
 RUNTIME_LIB = '/opt/gcc-arm-none-eabi-4_7-2013q3/lib/gcc/arm-none-eabi/4.7.4/<%= @platform.arch.arch %>/libgcc.a'
 RUSTC = 'rustc'
 
-features = [:tft_lcd, :multitasking]
+features = [:tft_lcd, :multitasking, :gpio_isr]
 
 Context.create(__FILE__, ENV['PLATFORM'], features)
 

--- a/apps/app_mrf_send.rs
+++ b/apps/app_mrf_send.rs
@@ -3,10 +3,10 @@
 #![no_std]
 
 extern crate zinc;
-extern crate std;
+extern crate core;
 
-use std::str::{Str, StrSlice};
-use std::slice::Vector;
+use core::str::{Str, StrSlice};
+use core::slice::Vector;
 
 use zinc::boards::mbed_lpc1768;
 use zinc::drivers::chario::CharIO;

--- a/apps/app_mrf_send.rs
+++ b/apps/app_mrf_send.rs
@@ -82,8 +82,8 @@ pub fn main() {
 
   uart.puts("MRF init...\n");
 
-  let mrf = mrf24j40::Mrf24j40::new(&spi, &timer, platform.reset, platform.cs,
-      platform.interrupt, 12);
+  let mrf = mrf24j40::Mrf24j40::new(&spi, &timer, &platform.reset, &platform.cs,
+      &platform.interrupt, 12);
 
   mrf.set_pan(0xcafe);
   mrf.set_short_address(0x6001);

--- a/apps/app_mrf_send.rs
+++ b/apps/app_mrf_send.rs
@@ -1,0 +1,85 @@
+#![crate_id="app"]
+#![crate_type="rlib"]
+#![no_std]
+
+extern crate zinc;
+
+use zinc::boards::mbed_lpc1768;
+use zinc::drivers::chario::CharIO;
+use zinc::drivers::mrf24j40;
+use zinc::hal::gpio::{GPIOConf, In, Out};
+use zinc::hal::pin::{map, Connected};
+use zinc::hal::spi::SPIConf;
+use zinc::hal::timer::{TimerConf, Timer};
+use zinc::hal::uart::{UARTConf, Disabled};
+
+#[cfg(mcu_lpc17xx)] use zinc::hal::lpc17xx::init::SysConf;
+#[cfg(mcu_lpc17xx)] use zinc::hal::lpc17xx;
+
+struct Platform {
+  configuration: SysConf,
+  timer: TimerConf,
+  uart: UARTConf,
+  spi: SPIConf,
+  cs: GPIOConf,
+  reset: GPIOConf,
+  interrupt: GPIOConf,
+}
+
+#[cfg(mcu_lpc17xx)]
+#[address_insignificant]
+static platform: Platform = Platform {
+  configuration: mbed_lpc1768::configuration,
+  timer: TimerConf {
+    timer: lpc17xx::timer::Timer1,
+    counter: 25,
+    divisor: 4,
+  },
+  uart: UARTConf {
+    peripheral: lpc17xx::uart::UART0,
+    baudrate: 115200,
+    word_len: 8,
+    parity: Disabled,
+    stop_bits: 1,
+
+    tx: map::port0::pin2::TXD0,
+    rx: map::port0::pin3::RXD0,
+  },
+  spi: SPIConf {
+    peripheral: lpc17xx::ssp::SSP1,
+    bits: 8,
+    mode: 0,
+    frequency: 20_000000,
+    mosi: Connected(map::port0::pin9::MOSI1),
+    miso: Connected(map::port0::pin8::MISO1),
+    sclk: Connected(map::port0::pin7::SCK1),
+  },
+  cs: GPIOConf {
+    pin: map::port0::pin6::GPIO,
+    direction: Out,
+  },
+  reset: GPIOConf {
+    pin: map::port0::pin1::GPIO,
+    direction: Out,
+  },
+  interrupt: GPIOConf {
+    pin: map::port2::pin5::GPIO,
+    direction: In,
+  }
+};
+
+#[no_split_stack]
+pub fn main() {
+  platform.configuration.setup();
+
+  let uart = &platform.uart.setup() as &CharIO;
+  let spi = platform.spi.setup();
+  let timer = platform.timer.setup();
+
+  let mrf = mrf24j40::Mrf24j40::new(&spi, &timer, platform.reset, platform.cs,
+      platform.interrupt, 12);
+
+  loop {
+    timer.wait(1);
+  }
+}

--- a/apps/app_mrf_send.rs
+++ b/apps/app_mrf_send.rs
@@ -3,6 +3,10 @@
 #![no_std]
 
 extern crate zinc;
+extern crate std;
+
+use std::str::{Str, StrSlice};
+use std::slice::Vector;
 
 use zinc::boards::mbed_lpc1768;
 use zinc::drivers::chario::CharIO;
@@ -76,10 +80,19 @@ pub fn main() {
   let spi = platform.spi.setup();
   let timer = platform.timer.setup();
 
+  uart.puts("MRF init...\n");
+
   let mrf = mrf24j40::Mrf24j40::new(&spi, &timer, platform.reset, platform.cs,
       platform.interrupt, 12);
 
+  mrf.set_pan(0xcafe);
+  mrf.set_short_address(0x6001);
+
+  uart.puts("PAN: "); uart.puth(mrf.get_pan() as u32); uart.puts("\n");
+  uart.puts("adr: "); uart.puth(mrf.get_short_address() as u32); uart.puts("\n");
   loop {
-    timer.wait(1);
+    uart.puts("Sending...\n");
+    mrf.send_to_short_address(0x6002, "hello".as_slice().as_bytes());
+    timer.wait(5);
   }
 }

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -18,3 +18,4 @@
 #[cfg(cfg_tft_lcd)] pub mod lcd;
 pub mod chario;
 pub mod dht22;
+pub mod mrf24j40;

--- a/src/drivers/mrf24j40.rs
+++ b/src/drivers/mrf24j40.rs
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::intrinsics::abort;
-use std::option::{Some, None};
-use std::slice::{ImmutableVector};
-use std::container::Container;
-use std::iter::Iterator;
+use core::intrinsics::abort;
+use core::option::{Some, None};
+use core::slice::{ImmutableVector};
+use core::container::Container;
+use core::iter::Iterator;
 
 use hal::gpio::{GPIOInterruptHandler, GPIO, GPIOConf, Falling};
 use hal::spi::SPI;

--- a/src/drivers/mrf24j40.rs
+++ b/src/drivers/mrf24j40.rs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::intrinsics::{abort, uninit};
+use std::intrinsics::abort;
 use std::option::{Some, None};
 use std::slice::{ImmutableVector};
 use std::container::Container;
 use std::iter::Iterator;
 
-use hal::gpio::{GPIOISRHandler, GPIO, GPIOConf, Falling};
+use hal::gpio::{GPIOInterruptHandler, GPIO, GPIOConf, Falling};
 use hal::spi::SPI;
 use hal::timer::Timer;
 
@@ -31,48 +31,28 @@ pub struct Mrf24j40<'a, S, T> {
   interrupt: GPIO<'a>,
 
   channel: u8,
-  interrupt_handler: InterruptHandler<'a, S, T>,
-}
-
-struct InterruptHandler<'a, S, T> {
-  driver: *Mrf24j40<'a, S, T>,
-}
-
-impl<'a, S: SPI, T: Timer> GPIOISRHandler for InterruptHandler<'a, S, T> {
-  fn handle_isr(&self) {
-    unsafe { (*self.driver).handle_isr() };
-  }
 }
 
 impl<'a, S: SPI, T: Timer> Mrf24j40<'a, S, T> {
   pub fn new(spi: &'a S, timer: &'a T, reset: &'a GPIOConf, cs: &'a GPIOConf,
       interrupt: &'a GPIOConf, initial_channel: u8) -> Mrf24j40<'a, S, T> {
     let int_gpio = interrupt.setup();
-    let mut radio = Mrf24j40 {
+    let radio = Mrf24j40 {
       spi: spi,
       timer: timer,
       reset: reset.setup(),
       cs: cs.setup(),
       interrupt: int_gpio,
       channel: initial_channel,
-      interrupt_handler: InterruptHandler {
-        driver: 0 as *Mrf24j40<S, T>,
-      }
     };
-
-    radio.interrupt_handler.driver = &radio as *Mrf24j40<S, T>;
 
     radio.hard_reset();
     radio.reinitialize();
 
-    int_gpio.set_interrupt_handler(Falling, Some(&radio.interrupt_handler
-        as &GPIOISRHandler));
+    int_gpio.set_interrupt_handler(Falling,
+        Some(&radio as &GPIOInterruptHandler));
 
     radio
-  }
-
-  fn handle_isr(&self) {
-    // TODO(farcaller): implement
   }
 
   fn hard_reset(&self) {
@@ -232,6 +212,12 @@ impl<'a, S: SPI, T: Timer> Mrf24j40<'a, S, T> {
     self.spi.transfer(lsb | 0x10);
     self.spi.transfer(val);
     self.cs.set_high();
+  }
+}
+
+impl<'a, S: SPI, T: Timer> GPIOInterruptHandler for Mrf24j40<'a, S, T> {
+  fn on_gpio_interrupt(&self) {
+
   }
 }
 

--- a/src/drivers/mrf24j40.rs
+++ b/src/drivers/mrf24j40.rs
@@ -1,0 +1,265 @@
+// Zinc, the bare metal stack for rust.
+// Copyright 2014 Vladimir "farcaller" Pouzanov <farcaller@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::intrinsics::abort;
+
+use hal::gpio::GPIOConf;
+use hal::spi::SPI;
+use hal::timer::Timer;
+
+pub struct Mrf24j40<'a, S, T> {
+  spi: &'a S,
+  timer: &'a T,
+  reset: GPIOConf,
+  cs: GPIOConf,
+  interrupt: GPIOConf,
+
+  channel: u8,
+}
+
+impl<'a, S: SPI, T: Timer> Mrf24j40<'a, S, T> {
+  pub fn new(spi: &'a S, timer: &'a T, reset: GPIOConf, cs: GPIOConf,
+      interrupt: GPIOConf, initial_channel: u8) -> Mrf24j40<'a, S, T> {
+    let radio = Mrf24j40 {
+      spi: spi,
+      timer: timer,
+      reset: *reset.setup(),
+      cs: *cs.setup(),
+      interrupt: *interrupt.setup(),
+      channel: initial_channel,
+    };
+
+    radio.reinitialize();
+
+    radio
+  }
+
+  /// Perform the initialization by the spec
+  fn reinitialize(&self) {
+    self.set_PACON2(0x98);
+    self.set_TXSTBL(0x95);
+    self.set_RFCON0(0x03);
+    self.set_RFCON1(0x01);
+    self.set_RFCON2(0x80);
+    self.set_RFCON6(0x90);
+    self.set_RFCON7(0x80);
+    self.set_RFCON8(0x10);
+    self.set_SLPCON1(0x21);
+
+    self.set_BBREG2(0x80);
+    self.set_CCAEDTH(0x60);
+    self.set_BBREG6(0x40);
+
+    self.enable_interrupts();
+    self.set_channel(self.channel);
+
+  }
+
+  pub fn set_channel(&self, channel: u8) {
+    if channel > 26 || channel < 11 {
+      unsafe { abort() }
+    }
+    // XXX: this also sets RFOPT to 3 (same as init value) to save on
+    // read-modify-write.
+    self.set_RFCON0((channel - 11) << 4 | 3);
+
+    self.set_RFCTL(0x04);
+    self.timer.wait_us(200);
+    self.set_RFCTL(0x00);
+    self.timer.wait_us(200);
+  }
+
+  fn enable_interrupts(&self) {
+    self.set_INTCON(0b11110110);  // enable rx & tx interrupts
+  }
+
+  fn reg_read_short(&self, adr: u8) -> u8 {
+    self.cs.set_low();
+    self.spi.transfer((adr << 1) & 0b01111110);
+    let val = self.spi.transfer(0);
+    self.cs.set_high();
+    val
+  }
+
+  fn reg_read_long(&self, adr: u16) -> u8 {
+    self.cs.set_low();
+    // Long address read
+    // 01 A9 A8 A7 A6 A5 A4 A3 A2 A1 A0 00
+    //  7  6  5  4  3  2  1  0              MSB
+    //                          7  6  5  4  LSB
+    let msb: u8 = (adr >> 3) as u8;
+    let lsb: u8 = (adr << 5) as u8;
+    self.spi.transfer(0x80 | msb);
+    self.spi.transfer(lsb);
+    let val = self.spi.transfer(0);
+    self.cs.set_high();
+    val
+  }
+
+  fn reg_write_short(&self, adr: u8, val: u8) {
+    self.cs.set_low();
+    self.spi.transfer((adr << 1 & 0b01111110) | 1);
+    self.spi.transfer(val);
+    self.cs.set_high();
+  }
+
+  fn reg_write_long(&self, adr: u16, val: u8) {
+    self.cs.set_low();
+    let msb: u8 = (adr >> 3) as u8;
+    let lsb: u8 = (adr << 5) as u8;
+    self.spi.transfer(0x80 | msb);
+    self.spi.transfer(lsb | 0x10);
+    self.spi.transfer(val);
+    self.cs.set_high();
+  }
+}
+
+macro_rules! reg_short_rw(
+  ($getter_name:ident, $setter_name:ident, $adr:expr) => (
+    impl<'a, S: SPI, T: Timer> Mrf24j40<'a, S, T> {
+      #[inline(always)]
+      pub fn $getter_name(&self) -> u8 {
+        self.reg_read_short($adr)
+      }
+
+      #[inline(always)]
+      pub fn $setter_name(&self, val: u8) {
+        self.reg_write_short($adr, val);
+      }
+    }
+  )
+)
+
+macro_rules! reg_long_rw(
+  ($getter_name:ident, $setter_name:ident, $adr:expr) => (
+    impl<'a, S: SPI, T: Timer> Mrf24j40<'a, S, T> {
+      #[inline(always)]
+      pub fn $getter_name(&self) -> u8 {
+        self.reg_read_long($adr)
+      }
+
+      #[inline(always)]
+      pub fn $setter_name(&self, val: u8) {
+        self.reg_write_long($adr, val);
+      }
+    }
+  )
+)
+
+reg_short_rw!(RXMCR,      set_RXMCR,      0x00)
+reg_short_rw!(PANIDL,     set_PANIDL,     0x01)
+reg_short_rw!(PANIDH,     set_PANIDH,     0x02)
+reg_short_rw!(SADRL,      set_SADRL,      0x03)
+reg_short_rw!(SADRH,      set_SADRH,      0x04)
+reg_short_rw!(EADR0,      set_EADR0,      0x05)
+reg_short_rw!(EADR1,      set_EADR1,      0x06)
+reg_short_rw!(EADR2,      set_EADR2,      0x07)
+reg_short_rw!(EADR3,      set_EADR3,      0x08)
+reg_short_rw!(EADR4,      set_EADR4,      0x09)
+reg_short_rw!(EADR5,      set_EADR5,      0x0a)
+reg_short_rw!(EADR6,      set_EADR6,      0x0b)
+reg_short_rw!(EADR7,      set_EADR7,      0x0c)
+reg_short_rw!(RXFLUSH,    set_RXFLUSH,    0x0d)
+reg_short_rw!(ORDER,      set_ORDER,      0x10)
+reg_short_rw!(TXMCR,      set_TXMCR,      0x11)
+reg_short_rw!(ACKTIMEOUT, set_ACKTIMEOUT, 0x12)
+reg_short_rw!(ESLOTG1,    set_ESLOTG1,    0x13)
+reg_short_rw!(SYMTICKL,   set_SYMTICKL,   0x14)
+reg_short_rw!(SYMTICKH,   set_SYMTICKH,   0x15)
+reg_short_rw!(PACON0,     set_PACON0,     0x16)
+reg_short_rw!(PACON1,     set_PACON1,     0x17)
+reg_short_rw!(PACON2,     set_PACON2,     0x18)
+reg_short_rw!(TXBCON0,    set_TXBCON0,    0x1a)
+reg_short_rw!(TXNCON,     set_TXNCON,     0x1b)
+reg_short_rw!(TXG1CON,    set_TXG1CON,    0x1c)
+reg_short_rw!(TXG2CON,    set_TXG2CON,    0x1d)
+reg_short_rw!(ESLOTG23,   set_ESLOTG23,   0x1e)
+reg_short_rw!(ESLOTG45,   set_ESLOTG45,   0x1f)
+reg_short_rw!(ESLOTG67,   set_ESLOTG67,   0x20)
+reg_short_rw!(TXPEND,     set_TXPEND,     0x21)
+reg_short_rw!(WAKECON,    set_WAKECON,    0x22)
+reg_short_rw!(FRMOFFSET,  set_FRMOFFSET,  0x23)
+reg_short_rw!(TXSTAT,     set_TXSTAT,     0x24)
+reg_short_rw!(TXBCON1,    set_TXBCON1,    0x25)
+reg_short_rw!(GATECLK,    set_GATECLK,    0x26)
+reg_short_rw!(TXTIME,     set_TXTIME,     0x27)
+reg_short_rw!(HSYMTMRL,   set_HSYMTMRL,   0x28)
+reg_short_rw!(HSYMTMRH,   set_HSYMTMRH,   0x29)
+reg_short_rw!(SOFTRST,    set_SOFTRST,    0x2a)
+reg_short_rw!(SECCON0,    set_SECCON0,    0x2c)
+reg_short_rw!(SECCON1,    set_SECCON1,    0x2d)
+reg_short_rw!(TXSTBL,     set_TXSTBL,     0x2e)
+reg_short_rw!(RXSR,       set_RXSR,       0x30)
+reg_short_rw!(INTSTAT,    set_INTSTAT,    0x31)
+reg_short_rw!(INTCON,     set_INTCON,     0x32)
+reg_short_rw!(GPIO,       set_GPIO,       0x33)
+reg_short_rw!(TRISGPIO,   set_TRISGPIO,   0x34)
+reg_short_rw!(SLPACK,     set_SLPACK,     0x35)
+reg_short_rw!(RFCTL,      set_RFCTL,      0x36)
+reg_short_rw!(SECCR2,     set_SECCR2,     0x37)
+reg_short_rw!(BBREG0,     set_BBREG0,     0x38)
+reg_short_rw!(BBREG1,     set_BBREG1,     0x39)
+reg_short_rw!(BBREG2,     set_BBREG2,     0x3a)
+reg_short_rw!(BBREG3,     set_BBREG3,     0x3b)
+reg_short_rw!(BBREG4,     set_BBREG4,     0x3c)
+reg_short_rw!(BBREG6,     set_BBREG6,     0x3e)
+reg_short_rw!(CCAEDTH,    set_CCAEDTH,    0x3f)
+
+reg_long_rw!(RFCON0,    set_RFCON0,    0x200)
+reg_long_rw!(RFCON1,    set_RFCON1,    0x201)
+reg_long_rw!(RFCON2,    set_RFCON2,    0x202)
+reg_long_rw!(RFCON3,    set_RFCON3,    0x203)
+reg_long_rw!(RFCON5,    set_RFCON5,    0x205)
+reg_long_rw!(RFCON6,    set_RFCON6,    0x206)
+reg_long_rw!(RFCON7,    set_RFCON7,    0x207)
+reg_long_rw!(RFCON8,    set_RFCON8,    0x208)
+reg_long_rw!(SLPCAL0,   set_SLPCAL0,   0x209)
+reg_long_rw!(SLPCAL1,   set_SLPCAL1,   0x20a)
+reg_long_rw!(SLPCAL2,   set_SLPCAL2,   0x20b)
+reg_long_rw!(RFSTATE,   set_RFSTATE,   0x20f)
+reg_long_rw!(RSSI,      set_RSSI,      0x210)
+reg_long_rw!(SLPCON0,   set_SLPCON0,   0x211)
+reg_long_rw!(SLPCON1,   set_SLPCON1,   0x220)
+reg_long_rw!(WAKETIMEL, set_WAKETIMEL, 0x222)
+reg_long_rw!(WAKETIMEH, set_WAKETIMEH, 0x223)
+reg_long_rw!(REMCNTL,   set_REMCNTL,   0x224)
+reg_long_rw!(REMCNTH,   set_REMCNTH,   0x225)
+reg_long_rw!(MAINCNT1,  set_MAINCNT1,  0x227)
+reg_long_rw!(MAINCNT2,  set_MAINCNT2,  0x228)
+reg_long_rw!(MAINCNT3,  set_MAINCNT3,  0x229)
+reg_long_rw!(TESTMODE,  set_TESTMODE,  0x22f)
+reg_long_rw!(ASSOEADR0, set_ASSOEADR0, 0x230)
+reg_long_rw!(ASSOEADR1, set_ASSOEADR1, 0x231)
+reg_long_rw!(ASSOEADR2, set_ASSOEADR2, 0x232)
+reg_long_rw!(ASSOEADR3, set_ASSOEADR3, 0x233)
+reg_long_rw!(ASSOEADR4, set_ASSOEADR4, 0x234)
+reg_long_rw!(ASSOEADR5, set_ASSOEADR5, 0x235)
+reg_long_rw!(ASSOEADR6, set_ASSOEADR6, 0x236)
+reg_long_rw!(ASSOEADR7, set_ASSOEADR7, 0x237)
+reg_long_rw!(ASSOSADR0, set_ASSOSADR0, 0x238)
+reg_long_rw!(ASSOSADR1, set_ASSOSADR1, 0x239)
+reg_long_rw!(UPNONCE0,  set_UPNONCE0,  0x240)
+reg_long_rw!(UPNONCE1,  set_UPNONCE1,  0x241)
+reg_long_rw!(UPNONCE2,  set_UPNONCE2,  0x242)
+reg_long_rw!(UPNONCE3,  set_UPNONCE3,  0x243)
+reg_long_rw!(UPNONCE4,  set_UPNONCE4,  0x244)
+reg_long_rw!(UPNONCE5,  set_UPNONCE5,  0x245)
+reg_long_rw!(UPNONCE6,  set_UPNONCE6,  0x246)
+reg_long_rw!(UPNONCE7,  set_UPNONCE7,  0x247)
+reg_long_rw!(UPNONCE8,  set_UPNONCE8,  0x248)
+reg_long_rw!(UPNONCE9,  set_UPNONCE9,  0x249)
+reg_long_rw!(UPNONCE10, set_UPNONCE10, 0x24a)
+reg_long_rw!(UPNONCE11, set_UPNONCE11, 0x24b)
+reg_long_rw!(UPNONCE12, set_UPNONCE12, 0x24c)

--- a/src/hal/gpio.rs
+++ b/src/hal/gpio.rs
@@ -34,3 +34,8 @@ pub enum Level {
   Low,
   High,
 }
+
+pub enum InterruptEdge {
+  Rising,
+  Falling,
+}

--- a/src/hal/gpio.rs
+++ b/src/hal/gpio.rs
@@ -39,3 +39,7 @@ pub enum InterruptEdge {
   Rising,
   Falling,
 }
+
+pub trait GPIOISRHandler {
+  fn handle_isr(&self);
+}

--- a/src/hal/gpio.rs
+++ b/src/hal/gpio.rs
@@ -40,6 +40,6 @@ pub enum InterruptEdge {
   Falling,
 }
 
-pub trait GPIOISRHandler {
-  fn handle_isr(&self);
+pub trait GPIOInterruptHandler {
+  fn on_gpio_interrupt(&self);
 }

--- a/src/hal/lpc17xx/gpio.rs
+++ b/src/hal/lpc17xx/gpio.rs
@@ -15,8 +15,8 @@
 
 //! GPIO configuration.
 
-use std::option::{Option, Some, None};
-use std::intrinsics::{abort, transmute};
+use core::option::{Option, Some, None};
+use core::intrinsics::{abort, transmute};
 
 use hal::gpio::{Direction, In, Out, Level, Low, High};
 use hal::gpio::{GPIOInterruptHandler, InterruptEdge, Rising, Falling};

--- a/src/hal/lpc17xx/gpio.rs
+++ b/src/hal/lpc17xx/gpio.rs
@@ -15,7 +15,11 @@
 
 //! GPIO configuration.
 
+use std::option::{Option, None};
+use std::intrinsics::abort;
+
 use hal::gpio::{Direction, In, Out, Level, Low, High};
+use hal::gpio::{InterruptEdge, Rising, Falling};
 use super::pin::{PinConf, Port0, Port1, Port2, Port3, Port4};
 
 #[path="../../lib/ioreg.rs"] mod ioreg;
@@ -82,6 +86,23 @@ impl<'a> GPIO<'a> {
     }
   }
 
+  pub fn set_interrupt_handler(&self, edge: InterruptEdge,
+      h: Option<GPIOHandler>) {
+    let b = match self.pin.port {
+      Port0 => match edge {
+        Rising  => GPIO0Rising,
+        Falling => GPIO0Falling,
+      },
+      Port2 => match edge {
+        Rising  => GPIO2Rising,
+        Falling => GPIO2Falling,
+      },
+      _ => unsafe { abort() },
+    };
+    set_gpio_handler(b, self.pin.pin, h)
+  }
+
+  #[inline(always)]
   fn reg(&self) -> &reg::GPIO {
     match self.pin.port {
       Port0 => &reg::GPIO0,
@@ -93,15 +114,142 @@ impl<'a> GPIO<'a> {
   }
 }
 
+pub type GPIOHandler = fn();
+type GPIOBank = [Option<GPIOHandler>, ..32];
+
+// TODO(farcaller): those static muts are accessed from both userland and isr,
+// so they must be synchronized in some way. Apparently, no scheduling should
+// happen while in gpio isr.
+static mut GPIO0RisingBank: GPIOBank = [None, ..32];
+static mut GPIO0FallingBank: GPIOBank = [None, ..32];
+static mut GPIO2RisingBank: GPIOBank = [None, ..32];
+static mut GPIO2FallingBank: GPIOBank = [None, ..32];
+
+enum GPIOInterruptHandlerBank {
+  GPIO0Rising,
+  GPIO0Falling,
+  GPIO2Rising,
+  GPIO2Falling,
+}
+
+impl GPIOInterruptHandlerBank {
+  pub fn bank(self) -> &mut GPIOBank {
+    unsafe {
+      match self {
+        GPIO0Rising  => &mut GPIO0RisingBank,
+        GPIO0Falling => &mut GPIO0FallingBank,
+        GPIO2Rising  => &mut GPIO2RisingBank,
+        GPIO2Falling => &mut GPIO2FallingBank,
+      }
+    }
+  }
+}
+
+fn set_gpio_handler(bank: GPIOInterruptHandlerBank, pin: u8,
+    h: Option<GPIOHandler>) {
+  bank.bank()[pin as uint] = h;
+}
+
+// TODO(farcaller): h shouldn't be called from isr, it actually should be passed
+// onto corresponding user task stack. DO NOT allow user code to run in MSP!
+// TODO(farcaller): this code is made with cmd+c / cmd+v.
+#[cfg(gpio_isr)]
+#[inline(always)]
+pub unsafe fn isr_gpio() {
+  let mut rise0 = reg::GPIOINT.IO0IntStatR();
+  let mut fall0 = reg::GPIOINT.IO0IntStatF();
+  let mut rise2 = reg::GPIOINT.IO2IntStatR();
+  let mut fall2 = reg::GPIOINT.IO2IntStatF();
+
+  while rise0 > 0 {
+    let bitloc = 31 - count_leading_zeroes(rise0);
+    let bank = GPIO0Rising.bank();
+    let handler = bank[bitloc];
+    match handler {
+      Some(h) => h(),
+      None => (),
+    }
+    let bit: u32 = 1 << bitloc;
+    reg::GPIOINT.set_IO0IntClr(bit);
+    rise0 -= bit;
+  }
+
+  while fall0 > 0 {
+    let bitloc = 31 - count_leading_zeroes(fall0);
+    let bank = GPIO0Falling.bank();
+    let handler = bank[bitloc];
+    match handler {
+      Some(h) => h(),
+      None => (),
+    }
+    let bit: u32 = 1 << bitloc;
+    reg::GPIOINT.set_IO0IntClr(bit);
+    fall0 -= bit;
+  }
+
+  while rise2 > 0 {
+    let bitloc = 31 - count_leading_zeroes(rise2);
+    let bank = GPIO2Rising.bank();
+    let handler = bank[bitloc];
+    match handler {
+      Some(h) => h(),
+      None => (),
+    }
+    let bit: u32 = 1 << bitloc;
+    reg::GPIOINT.set_IO2IntClr(bit);
+    rise2 -= bit;
+  }
+
+  while fall2 > 0 {
+    let bitloc = 31 - count_leading_zeroes(fall2);
+    let bank = GPIO2Falling.bank();
+    let handler = bank[bitloc];
+    match handler {
+      Some(h) => h(),
+      None => (),
+    }
+    let bit: u32 = 1 << bitloc;
+    reg::GPIOINT.set_IO2IntClr(bit);
+    fall2 -= bit;
+  }
+}
+
+#[inline(always)]
+fn count_leading_zeroes(val: u32) -> u8 {
+  let out: u32;
+  unsafe {
+    asm!("clz $0, $1" : "=r"(out) : "r"(val) :: "volatile");
+  }
+  out as u8
+}
+
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(GPIO: FIODIR, _r0, _r1, _r2, FIOMASK, FIOPIN, FIOSET, FIOCLR)
+  ioreg!(GPIO: FIODIR, _pad_0, _pad_1, _pad_2, FIOMASK, FIOPIN, FIOSET, FIOCLR)
   reg_rw!(GPIO, FIODIR,  set_FIODIR,  FIODIR)
   reg_rw!(GPIO, FIOMASK, set_FIOMASK, FIOMASK)
   reg_rw!(GPIO, FIOPIN,  set_FIOPIN,  FIOPIN)
   reg_rw!(GPIO, FIOSET,  set_FIOSET,  FIOSET)
   reg_rw!(GPIO, FIOCLR,  set_FIOCLR,  FIOCLR)
+
+  ioreg!(GPIOINTReg: IOIntStatus,
+      IO0IntStatR, IO0IntStatF, IO0IntClr, IO0IntEnR, IO0IntEnF,
+      _pad_0, _pad_1, _pad_2,
+      IO2IntStatR, IO2IntStatF, IO2IntClr, IO2IntEnR, IO2IntEnF)
+  reg_r!( GPIOINTReg, IOIntStatus,                IOIntStatus)
+
+  reg_r!( GPIOINTReg, IO0IntStatR,                IO0IntStatR)
+  reg_r!( GPIOINTReg, IO0IntStatF,                IO0IntStatF)
+  reg_w!( GPIOINTReg,              set_IO0IntClr, IO0IntClr)
+  reg_rw!(GPIOINTReg, IO0IntEnR,   set_IO0IntEnR, IO0IntEnR)
+  reg_rw!(GPIOINTReg, IO0IntEnF,   set_IO0IntEnF, IO0IntEnF)
+
+  reg_r!( GPIOINTReg, IO2IntStatR,                IO2IntStatR)
+  reg_r!( GPIOINTReg, IO2IntStatF,                IO2IntStatF)
+  reg_w!( GPIOINTReg,              set_IO2IntClr, IO2IntClr)
+  reg_rw!(GPIOINTReg, IO2IntEnR,   set_IO2IntEnR, IO2IntEnR)
+  reg_rw!(GPIOINTReg, IO2IntEnF,   set_IO2IntEnF, IO2IntEnF)
 
   extern {
     #[link_name="iomem_GPIO0"] pub static GPIO0: GPIO;
@@ -109,5 +257,7 @@ mod reg {
     #[link_name="iomem_GPIO2"] pub static GPIO2: GPIO;
     #[link_name="iomem_GPIO3"] pub static GPIO3: GPIO;
     #[link_name="iomem_GPIO4"] pub static GPIO4: GPIO;
+
+    #[link_name="iomem_GPIOINT"] pub static GPIOINT: GPIOINTReg;
   }
 }

--- a/src/hal/lpc17xx/gpio.rs
+++ b/src/hal/lpc17xx/gpio.rs
@@ -16,10 +16,10 @@
 //! GPIO configuration.
 
 use std::option::{Option, None};
-use std::intrinsics::abort;
+use std::intrinsics::{abort, transmute};
 
 use hal::gpio::{Direction, In, Out, Level, Low, High};
-use hal::gpio::{InterruptEdge, Rising, Falling};
+use hal::gpio::{GPIOISRHandler, InterruptEdge, Rising, Falling};
 use super::pin::{PinConf, Port0, Port1, Port2, Port3, Port4};
 
 #[path="../../lib/ioreg.rs"] mod ioreg;
@@ -87,7 +87,7 @@ impl<'a> GPIO<'a> {
   }
 
   pub fn set_interrupt_handler(&self, edge: InterruptEdge,
-      h: Option<GPIOHandler>) {
+      h: Option<&GPIOISRHandler>) {
     let b = match self.pin.port {
       Port0 => match edge {
         Rising  => GPIO0Rising,
@@ -114,8 +114,7 @@ impl<'a> GPIO<'a> {
   }
 }
 
-pub type GPIOHandler = fn();
-type GPIOBank = [Option<GPIOHandler>, ..32];
+type GPIOBank = [Option<&'static GPIOISRHandler>, ..32];
 
 // TODO(farcaller): those static muts are accessed from both userland and isr,
 // so they must be synchronized in some way. Apparently, no scheduling should
@@ -146,8 +145,8 @@ impl GPIOInterruptHandlerBank {
 }
 
 fn set_gpio_handler(bank: GPIOInterruptHandlerBank, pin: u8,
-    h: Option<GPIOHandler>) {
-  bank.bank()[pin as uint] = h;
+    h: Option<&GPIOISRHandler>) {
+  bank.bank()[pin as uint] = unsafe { transmute(h) };
 }
 
 // TODO(farcaller): h shouldn't be called from isr, it actually should be passed

--- a/src/hal/lpc17xx/iomem.ld
+++ b/src/hal/lpc17xx/iomem.ld
@@ -47,6 +47,8 @@ iomem_TIMER1    = 0x40008000;
 
 iomem_UART0     = 0x4000C000;
 
+iomem_GPIOINT   = 0x40028080;
+
 iomem_PINSEL0   = 0x4002C000;
 iomem_PINSEL1   = 0x4002C004;
 iomem_PINSEL2   = 0x4002C008;

--- a/src/lib/app.rs
+++ b/src/lib/app.rs
@@ -50,3 +50,10 @@ pub extern fn __morestack() {
 pub unsafe fn task_scheduler() {
   zinc::os::task::task_scheduler();
 }
+
+#[no_split_stack]
+#[no_mangle]
+#[cfg(cfg_gpio_isr, mcu_lpc17xx)]
+pub unsafe fn isr_eint_3() {
+  zinc::hal::lpc17xx::gpio::isr_gpio();
+}


### PR DESCRIPTION
This demo can talk to arduino and to contiki mote, which looks awesome. The code, however, isn't finished yet, I'll clean it up in a few upcoming days.

The primary reason for this driver is to raise code complexity and to see how zinc looks if things are starting to get tricky. So far, passing `timer` around feels a bit cumbersome.

The code doesn't support interrupts yet, as there are no interrupts in hal, that would be next piece of work to do before this PR lands.

Also, this code hardcodes parts of IEEE 802.15.4 MAC, which is a bit unreasonable, but acceptable for the moment. Further improvement should be done to decouple MAC from PHY (more complexity and more challanges).

Still pending:
 - [x] add interrupts support to LPC17xx GPIO
 - [ ] add NVIC management code
 - [ ] add interrupt handing to mrf code
 - [ ] document mrf code

Next steps:
 - [ ] decouple 802.15.4 MAC from PHY