### PR TITLE
Removes references to cast module.

### DIFF
--- a/src/hal/cortex_m3/isr.rs
+++ b/src/hal/cortex_m3/isr.rs
@@ -46,7 +46,7 @@ static ISRCount: uint = 16;
 
 #[link_section=".isr_vector"]
 #[no_mangle]
-pub static ISRVectors: [Option<extern unsafe fn()>, ..ISRCount] = [
+pub static ISRVectors: [Option<unsafe extern fn()>, ..ISRCount] = [
   Some(__STACK_BASE),
   Some(main),             // Reset
   Some(isr_nmi),          // NMI

--- a/src/hal/lpc17xx/isr.rs
+++ b/src/hal/lpc17xx/isr.rs
@@ -57,7 +57,7 @@ static ISRCount: uint = 35;
 
 #[link_section=".isr_vector_nvic"]
 #[no_mangle]
-pub static NVICVectors: [Option<extern unsafe fn()>, ..ISRCount] = [
+pub static NVICVectors: [Option<unsafe extern fn()>, ..ISRCount] = [
   // s.a. lpc17xx user manual, table 50 (chapter 6.3)
   Some(isr_wdt),
   Some(isr_timer_0),

--- a/src/lib/volatile_cell.rs
+++ b/src/lib/volatile_cell.rs
@@ -17,8 +17,9 @@
 
 use core::kinds::marker;
 use core::intrinsics::{volatile_load, volatile_store};
-use core::cast::transmute_mut_unsafe;
 
+// TODO(bharrisau) I don't know enough about markers - is it better
+// to just use an Unsafe<T> here instead?
 pub struct VolatileCell<T> {
   value: T,
   invariant: marker::InvariantType<T>,
@@ -42,7 +43,7 @@ impl<T> VolatileCell<T> {
   #[inline]
   pub fn set(&self, value: T) {
     unsafe {
-      volatile_store(&mut (*transmute_mut_unsafe(&self.value)), value)
+      volatile_store(&self.value as *T as *mut T, value)
     }
   }
 }

--- a/src/os/debug.rs
+++ b/src/os/debug.rs
@@ -15,8 +15,7 @@
 
 //! debug::port provides interface to output structured data over serial port.
 
-use core::mem::size_of;
-use core::cast::transmute;
+use core::mem::{size_of, transmute};
 use core::intrinsics::abort;
 
 use drivers::chario::CharIO;


### PR DESCRIPTION
Also fixes change from `extern unsafe` to `unsafe extern`. fixes #39
