### PR TITLE
Simplify compile process

### DIFF
--- a/src/hal/cortex_m3/isr.rs
+++ b/src/hal/cortex_m3/isr.rs
@@ -30,18 +30,6 @@ extern {
   fn isr_systick();
 }
 
-#[no_mangle]
-#[no_split_stack]
-pub extern fn isr_default_fault() {
-  unsafe {
-    asm!("mrs r0, psp
-        mrs r1, msp
-        ldr r2, [r0, 0x18]
-        ldr r3, [r1, 0x18]
-        bkpt")
-  }
-}
-
 static ISRCount: uint = 16;
 
 #[link_section=".isr_vector"]

--- a/src/hal/isr.rs
+++ b/src/hal/isr.rs
@@ -13,15 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! This file is not part of zinc crate, it is linked separately, alongside the
 //! ISRs for the platform.
-
-#![feature(asm, globs)]
-#![crate_id="isr"]
-#![crate_type="staticlib"]
-#![no_std]
-
-extern crate core;
 
 #[path="cortex_m3/isr.rs"] pub mod isr_cortex_m3;
 

--- a/src/hal/layout_common.ld
+++ b/src/hal/layout_common.ld
@@ -12,6 +12,8 @@ SECTIONS
     {
         FILL(0xff)
 
+        /* Make sure our default fault handler isn't garbage collected */
+        KEEP(*(.text.isr_default_fault))
         *(.text*)
         *(.rodata .rodata.*)
     } > rom

--- a/src/hal/mod.rs
+++ b/src/hal/mod.rs
@@ -23,6 +23,8 @@ and each such struct has a `setup()` method that configures the hardware
 
 mod mem_init;
 
+pub mod isr;
+
 #[cfg(mcu_lpc17xx)] pub mod lpc17xx;
 #[cfg(mcu_stm32f4)] pub mod stm32f4;
 

--- a/src/hal/stack.rs
+++ b/src/hal/stack.rs
@@ -16,13 +16,14 @@
 //! Stack layout information.
 
 extern {
-  static     __STACK_BASE: u32;
+  // This is called an fn in ISR so needs to be an fn here.
+  fn     __STACK_BASE();
   static mut __STACK_LIMIT: u32;
 }
 
 /// Returns the address of main stack base (end of ram).
 pub fn stack_base() -> u32 {
-  (&__STACK_BASE as *u32) as u32
+  (__STACK_BASE as *u32) as u32
 }
 
 /// Returns the current stack limit.

--- a/src/lib/app.rs
+++ b/src/lib/app.rs
@@ -17,8 +17,8 @@
 //! for stack management, scheduler, ISRs and other symbols with global
 //! visibility.
 
-#![crate_type="staticlib"]
 #![no_std]
+#![no_main]
 
 extern crate core;
 extern crate zinc;
@@ -26,7 +26,6 @@ extern crate app;
 
 #[no_split_stack]
 #[no_mangle]
-#[start]
 pub extern fn main() {
   app::main();
 }
@@ -48,6 +47,6 @@ pub extern fn __morestack() {
 #[no_split_stack]
 #[no_mangle]
 #[cfg(cfg_multitasking)]
-pub unsafe fn task_scheduler() {
+pub unsafe extern fn task_scheduler() {
   zinc::os::task::task_scheduler();
 }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -19,3 +19,4 @@ pub mod strconv;
 pub mod volatile_cell;
 pub mod shared;
 pub mod queue;
+pub mod support;

--- a/src/lib/support.rs
+++ b/src/lib/support.rs
@@ -13,16 +13,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_std]
-#![crate_type="rlib"]
-#![feature(asm)]
-
-extern "rust-intrinsic" {
-    fn offset<T>(dst: *T, offset: int) -> *T;
-}
+use core::intrinsics::offset;
 
 #[allow(non_camel_case_types)]
 pub type c_int = i32;
+
+#[lang = "stack_exhausted"]
+extern fn stack_exhausted() { /* ... */ }
+
+#[lang = "eh_personality"]
+extern fn eh_personality() { /* ... */ }
+
+#[lang = "begin_unwind"]
+extern fn begin_unwind() {
+    abort()
+}
+
+#[no_mangle]
+#[no_split_stack]
+pub extern "C" fn isr_default_fault() {
+  unsafe {
+    asm!("mrs r0, psp
+        mrs r1, msp
+        ldr r2, [r0, 0x18]
+        ldr r3, [r1, 0x18]
+        bkpt")
+  }
+}
 
 #[no_mangle]
 #[no_split_stack]

--- a/src/os/syscall.rs
+++ b/src/os/syscall.rs
@@ -20,6 +20,7 @@ This module provides syscall interface that is implemented in assembly due to
 current rust restrictions (see hal/cortex_m3/sched.S for actual implementation).
 */
 
+#[link(name = "isr_sched")]
 extern {
   pub fn syscall(f: fn(u32), arg: u32);
 }

--- a/support/build/context.rb
+++ b/support/build/context.rb
@@ -120,6 +120,10 @@ class Context
       "-L#{File.join(@env[:libs_path], @platform.arch.arch)}",
     ]
 
+    @env[:gccflags] = [
+      "-lgcc"
+    ]
+
     @env[:cflags] = [
       '-mthumb',
       "-mcpu=#{@platform.arch.cpu}",


### PR DESCRIPTION
Changes to libcore means we need to do the compile in less passes.

Added the three new lang items, pulled support into zinc, app is still
the main entry point but it produces the .elf without a second call to
ld.

There has been a large size regression, the majority of it is from
libcore pulling in the string formatting functions for error handling.
I will submit a patch to provide a cfg flag for building libcore
with simpler errors.
