### PR TITLE
Remove TOOLCHAIN_LIBS_PATH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
     - mv rust-nightly rust
     - cd ..
 before_script:
-    - export TOOLCHAIN_LIBS_PATH=/usr/lib/gcc/arm-none-eabi/4.8.3/
+    - export RUNTIME_LIB="/usr/lib/gcc/arm-none-eabi/4.8.3/<%= @platform.arch.arch %>/libgcc.a"
     - export RUSTC="`pwd`/rust-nightly-x86_64-unknown-linux-gnu/bin/rustc"
     - $RUSTC --version
 script:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Currently supported ARM MCUs:
 
 ## Usage
 
-Get a gcc cross-toolchain for arm and configure `TOOLCHAIN` and
-`TOOLCHAIN_LIBS_PATH` in Rakefile header as appropriate.
+Get a gcc cross-toolchain for arm and configure `TOOLCHAIN` and `RUNTIME_LIB` in
+Rakefile header as appropriate. `RUNTIME_LIB` should be either libgcc or
+libcompiler-rt ar archive, compiled for appropriate architecture.
 
 To build an application from apps/ use the following rake command:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 load 'support/rake.rb'
 
 TOOLCHAIN = 'arm-none-eabi-'
-TOOLCHAIN_LIBS_PATH = '/opt/gcc-arm-none-eabi-4_7-2013q3/lib/gcc/arm-none-eabi/4.7.4'
+RUNTIME_LIB = '/opt/gcc-arm-none-eabi-4_7-2013q3/lib/gcc/arm-none-eabi/4.7.4/<%= @platform.arch.arch %>/libgcc.a'
 RUSTC = 'rustc'
 
 features = [:tft_lcd, :multitasking]

--- a/support/rake.rb
+++ b/support/rake.rb
@@ -97,7 +97,7 @@ def link_binary(n, h)
     mapfn = Context.instance.build_dir(File.basename(t.name, File.extname(t.name)) + '.map')
 
     sh "#{:ld.in_toolchain} -Map #{mapfn} -o #{t.name} -T #{script} " +
-       "#{t.prerequisites.join(' ')} #{:ldflags.in_env.join(' ')} --gc-sections -lgcc"
+       "#{t.prerequisites.join(' ')} #{:ldflags.in_env.join(' ')} --gc-sections"
   end
 end
 


### PR DESCRIPTION
The runtime library is now loaded explicitly in RUNTIME_LIB env variable. This will allow better support for further switch away from libgcc.
