### PR TITLE
Hotfix for 0030-rm-integer-fallback.md RFC.

### DIFF
--- a/src/drivers/dht22.rs
+++ b/src/drivers/dht22.rs
@@ -58,7 +58,7 @@ impl<'a, T: Timer> DHT22<'a, T> {
       return None
     }
 
-    for _ in range(0, 40) {
+    for _ in range(0u, 40) {
       if !self.wait_while(Low, 80) {
         return None
       }

--- a/src/drivers/lcd/c12332.rs
+++ b/src/drivers/lcd/c12332.rs
@@ -121,10 +121,10 @@ impl<'a, S: SPI, T: Timer> C12332<'a, S, T> {
     let index = x + (y/8) * 128;
     if color == 0 {
       self.videobuf[index as uint].set(
-        self.videobuf[index as uint].get() & !(1 << (y%8) as u8));
+        self.videobuf[index as uint].get() & !(1 << (y%8) as uint) as u8);
     } else {
       self.videobuf[index as uint].set(
-        self.videobuf[index as uint].get() | (1 << (y%8)));
+        self.videobuf[index as uint].get() | (1 << ((y%8) as uint)));
     }
   }
 
@@ -174,7 +174,7 @@ impl<'a, S: SPI, T: Timer> C12332<'a, S, T> {
       i = 0;
       while i < hor {
         z =  zeichen[(bpl * i + ((j & 0xF8) >> 3)+1) as uint];
-        b = 1 << (j & 0x07);
+        b = 1 << ((j & 0x07) as uint);
         if ( z & b ) == 0x00 {
           self.set_pixel(x+i as i32, y+j as i32, 0);
         } else {

--- a/src/hal/lpc17xx/gpio.rs
+++ b/src/hal/lpc17xx/gpio.rs
@@ -49,17 +49,17 @@ impl GPIOConf {
 impl GPIO {
   /// Sets output GPIO value to high.
   pub fn set_high(&self) {
-    self.reg().set_FIOSET(1 << self.pin.pin);
+    self.reg().set_FIOSET(1 << (self.pin.pin as uint));
   }
 
   /// Sets output GPIO value to low.
   pub fn set_low(&self) {
-    self.reg().set_FIOCLR(1 << self.pin.pin);
+    self.reg().set_FIOCLR(1 << (self.pin.pin as uint));
   }
 
   /// Sets output GPIO direction.
   pub fn set_direction(&self, new_mode: Direction) {
-    let bit: u32 = 1 << self.pin.pin;
+    let bit: u32 = 1 << (self.pin.pin as uint);
     let mask: u32 = !bit;
     let reg = self.reg();
     let val: u32 = reg.FIODIR();
@@ -73,7 +73,7 @@ impl GPIO {
 
   /// Returns input GPIO level.
   pub fn level(&self) -> Level {
-    let bit: u32 = 1 << self.pin.pin;
+    let bit: u32 = 1 << (self.pin.pin as uint);
     let reg = self.reg();
 
     match reg.FIOPIN() & bit {

--- a/src/hal/lpc17xx/init.rs
+++ b/src/hal/lpc17xx/init.rs
@@ -143,7 +143,7 @@ fn init_flash_access(freq: u32) {
 }
 
 #[inline(always)]
-fn wait_for_pll0stat_bit(bit: u32) {
+fn wait_for_pll0stat_bit(bit: uint) {
   wait_for!(reg::PLL0STAT.value() & (1 << bit) == (1 << bit));
 }
 

--- a/src/hal/lpc17xx/peripheral_clock.rs
+++ b/src/hal/lpc17xx/peripheral_clock.rs
@@ -101,14 +101,14 @@ pub enum PeripheralDivisor {
 impl PeripheralClock {
   /// Enables the given peripheral clock.
   pub fn enable(self) {
-    let bit: u32 = 1 << self as u32;
+    let bit: u32 = (1 << (self as uint)) as u32;
     let val: u32 = reg::PCONP.value();
     reg::PCONP.set_value(val | bit);
   }
 
   /// Disables the given peripheral clock.
   pub fn disable(self) {
-    let bit: u32 = !(1 << self as u32);
+    let bit: u32 = !((1 << (self as uint)) as u32);
     let val: u32 = reg::PCONP.value();
     reg::PCONP.set_value(val & bit);
   }
@@ -121,7 +121,7 @@ impl PeripheralClock {
   /// Returns the given peripheral clock divisor.
   pub fn get_divisor(self) -> u8 {
     let (reg, offset) = self.divisor_reg_and_offset();
-    let val = (reg.value() >> offset) & 3;
+    let val = (reg.value() >> (offset as uint)) & 3;
     match val {
       1 => 1,
       2 => 2,
@@ -146,8 +146,8 @@ impl PeripheralClock {
       _   => unsafe { abort() },
     };
 
-    let bits: u32 = divisor_value as u32 << offset as u32;
-    let mask: u32 = !(3 << offset as u32);
+    let bits: u32 = divisor_value as u32 << (offset as uint);
+    let mask: u32 = !((3 << (offset as uint)) as u32);
     let val: u32 = reg.value();
     reg.set_value(val & mask | bits);
   }

--- a/src/hal/lpc17xx/pin.rs
+++ b/src/hal/lpc17xx/pin.rs
@@ -62,8 +62,8 @@ impl PinConf {
   pub fn setup(&self) {
     let (offset, reg) = self.get_pinsel_reg_and_offset();
 
-    let fun_bits: u32  = self.function as u32 << (offset*2);
-    let mask_bits: u32 = !(3u32 << (offset*2));
+    let fun_bits: u32  = self.function as u32 << (offset as uint * 2);
+    let mask_bits: u32 = !(3u32 << (offset as uint * 2));
 
     let val: u32 = reg.value();
     let new_val = (val & mask_bits) | fun_bits;

--- a/src/hal/lpc17xx/platformtree.rs
+++ b/src/hal/lpc17xx/platformtree.rs
@@ -171,7 +171,7 @@ pub fn build_gpio(builder: &mut Builder, cx: &mut ExtCtxt,
   for (port_path, port_node) in node.subnodes.iter() {
     if !port_node.expect_no_attributes(cx) { continue }
 
-    let port_str = format!("pin::Port{}", match from_str(port_path.as_slice()).unwrap() {
+    let port_str = format!("pin::Port{}", match from_str::<uint>(port_path.as_slice()).unwrap() {
       0..4 => port_path,
       other => {
         cx.parse_sess().span_diagnostic.span_err(port_node.path_span,
@@ -203,7 +203,7 @@ pub fn build_gpio(builder: &mut Builder, cx: &mut ExtCtxt,
       };
       let direction = TokenString::new(direction_str.to_str());
 
-      let pin_str = match from_str(pin_path.as_slice()).unwrap() {
+      let pin_str = match from_str::<uint>(pin_path.as_slice()).unwrap() {
         0..31 => pin_path,
         other => {
           cx.parse_sess().span_diagnostic.span_err(pin_node.path_span,


### PR DESCRIPTION
Fixes all the breakage caused by [0030-rm-integer-fallback](https://github.com/rust-lang/rfcs/blob/master/complete/0030-rm-integer-fallback.md) as reported by @errordeveloper.
