### PR TITLE
Determine path to libgcc.a automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ install:
     - mv rust-nightly rust
     - cd ..
 before_script:
-    - export RUNTIME_LIB="/usr/lib/gcc/arm-none-eabi/4.8.4/<%= @platform.arch.arch %>/libgcc.a"
     - export RUSTC="`pwd`/rust-nightly-x86_64-unknown-linux-gnu/bin/rustc"
     - $RUSTC --version
 script:

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 load 'support/rake.rb'
 
 TOOLCHAIN = 'arm-none-eabi-'
-RUNTIME_LIB = '/opt/gcc-arm-none-eabi-4_8-2014q2/lib/gcc/arm-none-eabi/4.8.4/<%= @platform.arch.arch %>/libgcc.a'
 RUSTC = 'rustc'
 
 features = [:tft_lcd]

--- a/support/build/context.rb
+++ b/support/build/context.rb
@@ -91,12 +91,6 @@ class Context
     super *args
   end
 
-  def resolve_runtime_lib
-    lib_tpl = env_const(:RUNTIME_LIB)
-    tpl = ERB.new(lib_tpl)
-    tpl.result(binding)
-  end
-
   def collect_config_flags!
     @config_flags = (@platform.features + @build_features).map do |f|
       "cfg_#{f}"
@@ -124,12 +118,13 @@ class Context
       '-Z no-landing-pads',
     ] + @config_flags
 
-    @env[:ldflags] = [resolve_runtime_lib]
 
     @env[:cflags] = [
       '-mthumb',
       "-mcpu=#{@platform.arch.cpu}",
     ]
+
+    @env[:ldflags] = [ %x( #{TOOLCHAIN}gcc -print-libgcc-file-name #{@env[:cflags].join(' ')}).chomp ]
 
     @env[:rustc] = env_const(:RUSTC)
     @env[:toolchain] = env_const(:TOOLCHAIN)


### PR DESCRIPTION
[Was](https://travis-ci.org/hackndev/zinc/jobs/28587341#L116): `/usr/lib/gcc/arm-none-eabi/4.8.4/armv7-m/libgcc.a`
[Now](https://travis-ci.org/errordeveloper/zinc/jobs/28588446#L114): `/usr/bin/../lib/gcc/arm-none-eabi/4.8.4/armv7-m/libgcc.a`
