### PR TITLE
Fix documentation typos

### DIFF
--- a/src/drivers/dht22.rs
+++ b/src/drivers/dht22.rs
@@ -19,7 +19,7 @@ use core::iter::{Iterator, range};
 use hal::pin::{GPIO, Low, High, In, Out, GPIOLevel};
 use hal::timer::Timer;
 
-/// Basic DHT22 driver ported over from arduino example.
+/// Basic DHT22 driver ported over from Arduino example.
 pub struct DHT22<'a, T, P> {
   gpio: &'a P,
   timer: &'a T,

--- a/src/drivers/lcd/mod.rs
+++ b/src/drivers/lcd/mod.rs
@@ -30,7 +30,7 @@ pub mod font_small_7;
 /// `pixel` to set a pixel.
 ///
 /// LCD does not flush buffers automatically, user must call `flush` after the
-/// drwaing sequence to actually display the data on screen.
+/// drawing sequence to actually display the data on screen.
 pub trait LCD : CharIO {
   /// Clears the screen.
   fn clear(&self);

--- a/src/hal/mod.rs
+++ b/src/hal/mod.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 /*!
-HAL provides abstactions for specific MCU hardware.
+HAL provides abstractions for specific MCU hardware.
 
 Each peripheral in `hal` has a `xxxConf` struct that can be defined statically,
 and each such struct has a `setup()` method that configures the hardware

--- a/src/hal/stm32f4/init.rs
+++ b/src/hal/stm32f4/init.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Rotines for initialization of NXP LPC17xx.
+//! Routines for initialization of NXP LPC17xx.
 //!
 //! This module includes code for setting up the clock, flash, access time and
 //! performing initial peripheral configuration.

--- a/src/hal/timer.rs
+++ b/src/hal/timer.rs
@@ -18,7 +18,7 @@ Timer interface.
 
 TimerConf is a MCU-specific struct.
 
-Timers porvide a simple way to delay program executon for some time.
+Timers provide a simple way to delay program execution for some time.
 */
 
 #[path="../lib/wait_for.rs"] mod wait_for;


### PR DESCRIPTION
Fix typos found by spell-checking the documentation.
