### PR TITLE
Add warning for missing doc comments

### DIFF
--- a/macro/platformtree.rs
+++ b/macro/platformtree.rs
@@ -15,6 +15,7 @@
 
 #![crate_name="macro_platformtree"]
 #![crate_type="dylib"]
+#![warn(missing_doc)]
 
 #![feature(plugin_registrar, quote, managed_boxes)]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@
 #![crate_name="zinc"]
 #![crate_type="rlib"]
 #![allow(ctypes)]
+#![warn(missing_doc)]
 #![no_std]
 
 /*!


### PR DESCRIPTION
First step in phasing over to deny mode. There are 129 missing comments
at the moment - the warning is to prevent the creation of more as
we catch up.
