### PR TITLE
[fix] warning: use of deprecated item: prefer using indexing

### DIFF
--- a/platformtree/builder/os.rs
+++ b/platformtree/builder/os.rs
@@ -227,7 +227,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts.len() == 1);
 
-      assert_equal_source(builder.main_stmts.get(0),
+      assert_equal_source(builder.main_stmts[0],
           "loop {
             run();
           }");
@@ -256,14 +256,14 @@ mod test {
       assert!(builder.main_stmts.len() == 1);
       assert!(builder.type_items.len() == 1);
 
-      assert_equal_source(&cx.stmt_item(DUMMY_SP, *builder.type_items.get(0)),
+      assert_equal_source(cx.stmt_item(DUMMY_SP, builder.type_items[0]),
           "pub struct run_args<'a> {
             pub a: u32,
             pub b: &'static str,
             pub c: &'a hello::world::Struct,
           }");
 
-      assert_equal_source(builder.main_stmts.get(0),
+      assert_equal_source(builder.main_stmts[0],
           "loop {
             run(&pt::run_args {
               a: 1u,

--- a/platformtree/test_helpers.rs
+++ b/platformtree/test_helpers.rs
@@ -114,7 +114,7 @@ impl Emitter for CustomEmmiter {
   }
 }
 
-pub fn assert_equal_source(stmt: &Gc<ast::Stmt>, src: &str) {
+pub fn assert_equal_source(stmt: Gc<ast::Stmt>, src: &str) {
   let gen_src = pprust::stmt_to_string(stmt.deref());
   println!("generated: {}", gen_src);
   println!("expected:  {}", src);
@@ -125,7 +125,7 @@ pub fn assert_equal_source(stmt: &Gc<ast::Stmt>, src: &str) {
   assert!(stripped_gen_src == stripped_src);
 }
 
-pub fn assert_equal_items(stmt: &Gc<ast::Item>, src: &str) {
+pub fn assert_equal_items(stmt: Gc<ast::Item>, src: &str) {
   let gen_src = pprust::item_to_string(stmt.deref());
   println!("generated: {}", gen_src);
   println!("expected:  {}", src);

--- a/src/drivers/dht22_pt.rs
+++ b/src/drivers/dht22_pt.rs
@@ -91,7 +91,7 @@ mod test {
       assert_that(unsafe{*failed}, is(equal_to(false)));
       assert_that(builder.main_stmts().len(), is(equal_to(1u)));
 
-      assert_equal_source(builder.main_stmts().get(0),
+      assert_equal_source(builder.main_stmts()[0],
           "let dht = zinc::drivers::dht22::DHT22::new(&timer, &pin);");
 
       let pin_node = pt.get_by_name("pin").unwrap();

--- a/src/hal/lpc17xx/pin_pt.rs
+++ b/src/hal/lpc17xx/pin_pt.rs
@@ -89,16 +89,16 @@ fn build_pin(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
     None => "GPIO".to_string(),
     Some(fun) => {
       let pins = port_def.get(port_path);
-      let maybe_pin = pins.get(from_str(node.path.as_slice()).unwrap());
-      match maybe_pin {
-        &None => {
+      let maybe_pin_index = from_str(node.path.as_slice()).unwrap();
+      match pins[maybe_pin_index] {
+        None => {
           cx.parse_sess().span_diagnostic.span_err(
               node.get_attr("function").value_span,
               format!("unknown pin function `{}`, only GPIO avaliable on this pin",
                   fun).as_slice());
           return;
         }
-        &Some(ref pin_funcs) => {
+        Some(ref pin_funcs) => {
           let maybe_func = pin_funcs.find(&fun);
           match maybe_func {
             None => {
@@ -152,7 +152,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts().len() == 1);
 
-      assert_equal_source(builder.main_stmts().get(0),
+      assert_equal_source(builder.main_stmts()[0],
           "let p1 = zinc::hal::lpc17xx::pin::Pin::new(
                zinc::hal::lpc17xx::pin::Port0,
                1u8,
@@ -174,7 +174,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts().len() == 1);
 
-      assert_equal_source(builder.main_stmts().get(0),
+      assert_equal_source(builder.main_stmts()[0],
           "let p2 = zinc::hal::lpc17xx::pin::Pin::new(
                zinc::hal::lpc17xx::pin::Port0,
                2u8,
@@ -196,7 +196,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts().len() == 1);
 
-      assert_equal_source(builder.main_stmts().get(0),
+      assert_equal_source(builder.main_stmts()[0],
           "let p3 = zinc::hal::lpc17xx::pin::Pin::new(
                zinc::hal::lpc17xx::pin::Port0,
                3u8,

--- a/src/hal/lpc17xx/platformtree.rs
+++ b/src/hal/lpc17xx/platformtree.rs
@@ -121,7 +121,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(items.len() == 3);
 
-      assert_equal_items(items.get(1), "
+      assert_equal_items(items[1], "
           #[no_mangle]
           #[no_split_stack]
           #[allow(unused_variable)]

--- a/src/hal/lpc17xx/system_clock_pt.rs
+++ b/src/hal/lpc17xx/system_clock_pt.rs
@@ -131,7 +131,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts().len() == 1);
 
-      assert_equal_source(builder.main_stmts().get(0),
+      assert_equal_source(builder.main_stmts()[0],
           "{
             use zinc::hal::lpc17xx::system_clock;
             system_clock::init_clock(

--- a/src/hal/lpc17xx/timer_pt.rs
+++ b/src/hal/lpc17xx/timer_pt.rs
@@ -89,7 +89,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts().len() == 1);
 
-      assert_equal_source(builder.main_stmts().get(0),
+      assert_equal_source(builder.main_stmts()[0],
           "let tim = zinc::hal::lpc17xx::timer::Timer::new(
               zinc::hal::lpc17xx::timer::Timer1, 25u32, 4u8);");
     });

--- a/src/hal/lpc17xx/uart_pt.rs
+++ b/src/hal/lpc17xx/uart_pt.rs
@@ -152,7 +152,7 @@ mod test {
       assert!(unsafe{*failed} == false);
       assert!(builder.main_stmts().len() == 1);
 
-      assert_equal_source(builder.main_stmts().get(0),
+      assert_equal_source(builder.main_stmts()[0],
           "let uart = zinc::hal::lpc17xx::uart::UART::new(
                zinc::hal::lpc17xx::uart::UART0,
                9600u32,


### PR DESCRIPTION
Fixing this in just the `src/hal/lpc17xx/pin_pt.rs` first results in:

```
error: mismatched types: expected `core::option::Option<std::collections::hashmap::HashMap<collections::string::String,uint>>` but found an `&`-pointer pattern
```

Fixing the above error, gives this:

```
error: cannot move out of dereference (dereference is implicit, due to indexing)
```
