### PR TITLE
Doc comments for hal and lib.

### DIFF
--- a/src/hal/cortex_common/nvic.rs
+++ b/src/hal/cortex_common/nvic.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Interface to Nested Vector Interrupt Controller
+//! Interface to Nested Vector Interrupt Controller.
 //  Link: http://infocenter.arm.com/help/topic/com.arm.doc.dui0552a/CIHIGCIF.html
 
 #[path="../../lib/ioreg.rs"] mod ioreg;

--- a/src/hal/cortex_common/scb.rs
+++ b/src/hal/cortex_common/scb.rs
@@ -18,13 +18,13 @@
 
 #[path="../../lib/ioreg.rs"] mod ioreg;
 
-/// Returns the CPUID
+/// Returns the CPUID.
 #[allow(dead_code)]
 pub fn cpuid() -> u32 {
   reg::SCB.CPUID()
 }
 
-/// Sets the pending state of the PendSV interrupt
+/// Sets the pending state of the PendSV interrupt.
 pub fn set_pendsv(val: bool) {
   if val {
     reg::SCB.set_ICSR(1 << 28);

--- a/src/hal/cortex_common/systick.rs
+++ b/src/hal/cortex_common/systick.rs
@@ -56,7 +56,7 @@ pub fn disable_irq() {
   reg::SYSTICK.set_CONTROL(reg::SYSTICK.CONTROL() & !0b010);
 }
 
-/// Gets the current 24bit systick value
+/// Gets the current 24bit systick value.
 pub fn get_current() -> u32 {
   reg::SYSTICK.CURRENT() & 0xFFFFFF
 }

--- a/src/hal/cortex_m3/sched.rs
+++ b/src/hal/cortex_m3/sched.rs
@@ -100,7 +100,7 @@ unsafe fn task_finished() {
 #[cfg(test)]
 unsafe fn task_finished() { unimplemented!() }
 
-/// Phantom type to indicate that interrupts are disabled
+/// Phantom type to indicate that interrupts are disabled.
 pub struct NoInterrupts {
   contents: ()
 }

--- a/src/hal/k20/mod.rs
+++ b/src/hal/k20/mod.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! HAL for Freescale Kinetis K20
+//! HAL for Freescale Kinetis K20.
 
 pub mod sim;
 pub mod pin;

--- a/src/hal/k20/pin.rs
+++ b/src/hal/k20/pin.rs
@@ -20,8 +20,7 @@ Some pins that could be configured here may be missing from actual MCU depending
 on the package.
 */
 
-use core::intrinsics::abort;
-use core::option::{Option, Some, None};
+use core::option::Option;
 
 use lib::volatile_cell::VolatileCell;
 
@@ -29,13 +28,15 @@ use super::sim;
 
 #[path="../../lib/ioreg.rs"] mod ioreg;
 
-/// A pin
+/// A pin.
+#[allow(missing_doc)]
 pub struct Pin {
   pub port: Port,
   pub pin: u8,
 }
 
 /// Available port names.
+#[allow(missing_doc)]
 pub enum Port {
   PortA = 1,
   PortB = 2,
@@ -46,6 +47,7 @@ pub enum Port {
 
 /// Pin functions (GPIO or up to seven additional functions).
 #[deriving(PartialEq)]
+#[allow(missing_doc)]
 pub enum Function {
   Analog       = 0,
   GPIO         = 1,
@@ -57,26 +59,30 @@ pub enum Function {
   AltFunction7 = 7,
 }
 
-/// Pull-up/-down configuration
+/// Pull-up/-down configuration.
+#[allow(missing_doc)]
 pub enum PullConf {
   PullNone   = 0,
   PullUp     = 1,
   PullDown   = 2,
 }
 
-/// Pin output driver strength
+/// Pin output driver strength.
+#[allow(missing_doc)]
 pub enum DriveStrength {
   DriveStrengthHigh   = 0,
   DriveStrengthLow    = 1,
 }
 
-/// Pin output drive slew rate
+/// Pin output drive slew rate.
+#[allow(missing_doc)]
 pub enum SlewRate {
   SlewFast   = 0,
   SlewSlow   = 1,
 }
 
 impl Pin {
+  /// Create and setup a Pin.
   pub fn new(port: Port, pin_index: u8, function: Function,
       gpiodir: Option<::hal::pin::GPIODirection>) -> Pin {
     let pin = Pin {
@@ -89,12 +95,12 @@ impl Pin {
     pin
   }
 
-  pub fn setup_regs(&self, function: Function,
+  fn setup_regs(&self, function: Function,
       gpiodir: Option<::hal::pin::GPIODirection>,
       pull: PullConf, drive_strength: DriveStrength,
       slew_rate: SlewRate, filter: bool, open_drain: bool) {
     // enable port clock
-    sim::reg::SIM.set_SCGC5(sim::reg::SIM.SCGC5() | (1 << (self.port as uint + 8)));
+    sim::enable_PORT(self.port as uint);
 
     let value =
           (pull as u32 << 0)

--- a/src/hal/k20/sim.rs
+++ b/src/hal/k20/sim.rs
@@ -13,9 +13,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! HAL for Kinetis SIM module.
+
 #[path="../../lib/ioreg.rs"] mod ioreg;
 
-pub mod reg {
+/// Enable clock to a PORTx peripheral
+#[allow(non_snake_case_functions)]
+pub fn enable_PORT(num: uint) {
+  reg::SIM.set_SCGC5(reg::SIM.SCGC5() | (1 << (num + 8)));
+}
+
+#[allow(dead_code)]
+mod reg {
   use lib::volatile_cell::VolatileCell;
 
   #[allow(uppercase_variables)]

--- a/src/hal/k20/uart.rs
+++ b/src/hal/k20/uart.rs
@@ -26,23 +26,27 @@ use hal::uart;
 #[path="../../lib/wait_for.rs"] mod wait_for;
 
 /// Available UART peripherals.
+#[allow(missing_doc)]
 pub enum UARTPeripheral {
   UART0,
   UART1,
   UART2,
 }
 
+/// Structure describing a UART instance.
 pub struct UART {
   reg: &'static reg::UART,
 }
 
 /// UART word length.
+#[allow(missing_doc)]
 pub enum WordLen {
   WordLen8bits = 0,
   WordLen9bits = 0b00010000,
 }
 
 impl WordLen {
+  /// Convert from number to WordLen.
   pub fn from_u8(val: u8) -> WordLen {
     match val {
       8 => WordLen8bits,
@@ -53,12 +57,14 @@ impl WordLen {
 }
 
 /// Stop bits configuration.
-/// K20 UART only supports one stop bit
+/// K20 UART only supports one stop bit.
 pub enum StopBit {
+  /// Single stop bit.
   StopBit1bit  = 0,
 }
 
 impl StopBit {
+  /// Convert from number to StopBit.
   pub fn from_u8(val: u8) -> StopBit {
     match val {
       1 => StopBit1bit,
@@ -117,7 +123,7 @@ impl UART {
   }
 
   #[no_split_stack]
-  fn set_mode(&self, word_len: WordLen, parity: uart::Parity, stop_bits: StopBit) {
+  fn set_mode(&self, word_len: WordLen, parity: uart::Parity, _: StopBit) {
     let c1: u8 = (*(self.reg)).C1();
     let computed_val: u8 = word_len as u8 | match parity {
       uart::Disabled => PEDisabled as u8  | PSOdd as u8,

--- a/src/hal/lpc17xx/peripheral_clock.rs
+++ b/src/hal/lpc17xx/peripheral_clock.rs
@@ -26,6 +26,7 @@ use super::system_clock::system_clock;
 #[path="../../lib/ioreg.rs"] mod ioreg;
 
 /// Configures the state of peripheral clock.
+#[allow(missing_doc)]
 pub enum PeripheralClock {
   // reserved = 0,
   TIM0Clock  = 1,
@@ -62,6 +63,7 @@ pub enum PeripheralClock {
 }
 
 /// Configures the divisor of peripheral clock based on core clock.
+#[allow(missing_doc)]
 pub enum PeripheralDivisor {
   WDTDivisor     = 0,
   TIMER0Divisor  = 2,

--- a/src/hal/lpc17xx/pin.rs
+++ b/src/hal/lpc17xx/pin.rs
@@ -26,6 +26,7 @@ use core::option::{Option};
 #[path="../../lib/ioreg.rs"] mod ioreg;
 
 /// Available port names.
+#[allow(missing_doc)]
 pub enum Port {
   Port0,
   Port1,
@@ -36,6 +37,7 @@ pub enum Port {
 
 /// Pin functions (GPIO or up to three additional functions).
 #[deriving(PartialEq)]
+#[allow(missing_doc)]
 pub enum Function {
   GPIO         = 0,
   AltFunction1 = 1,
@@ -43,12 +45,16 @@ pub enum Function {
   AltFunction3 = 3,
 }
 
+/// Structure to describe the location of a pin
 pub struct Pin {
+  /// Port the pin is attached to
   port: Port,
+  /// Pin number in the port
   pin: u8
 }
 
 impl Pin {
+  /// Create and setup a Pin
   pub fn new(port: Port, pin_index: u8, function: Function,
       gpiodir: Option<::hal::pin::GPIODirection>) -> Pin {
     let pin = Pin {

--- a/src/hal/lpc17xx/system_clock.rs
+++ b/src/hal/lpc17xx/system_clock.rs
@@ -69,6 +69,7 @@ pub fn system_clock() -> u32 {
   unsafe { SystemClock }
 }
 
+/// Initialise the system clock.
 #[inline(always)]
 pub fn init_clock(clock: &Clock) {
   let src_clock: u32 = match clock.source {

--- a/src/hal/lpc17xx/timer.rs
+++ b/src/hal/lpc17xx/timer.rs
@@ -25,6 +25,7 @@ use hal::timer;
 #[path="../../lib/ioreg.rs"] mod ioreg;
 
 /// Available timer peripherals.
+#[allow(missing_doc)]
 pub enum TimerPeripheral {
   Timer0,
   Timer1,
@@ -42,11 +43,13 @@ pub struct TimerConf {
   pub divisor: u8,
 }
 
+/// Struct describing a timer instance.
 pub struct Timer {
   reg: &'static reg::TIMER,
 }
 
 impl Timer {
+  /// Create an start a timer.
   pub fn new(peripheral: TimerPeripheral, counter: u32, divisor: u8) -> Timer {
     let (clock, reg) = match peripheral {
       Timer0 => (peripheral_clock::TIM0Clock, &reg::TIMER0),

--- a/src/hal/lpc17xx/uart.rs
+++ b/src/hal/lpc17xx/uart.rs
@@ -30,6 +30,7 @@ use hal::uart;
 #[path="../../lib/wait_for.rs"] mod wait_for;
 
 /// Available UART peripherals.
+#[allow(missing_doc)]
 pub enum UARTPeripheral {
   UART0,
   UART2,
@@ -37,6 +38,7 @@ pub enum UARTPeripheral {
 }
 
 /// UART word length.
+#[allow(missing_doc)]
 pub enum WordLen {
   WordLen5bits = 0b00,
   WordLen6bits = 0b01,
@@ -45,6 +47,7 @@ pub enum WordLen {
 }
 
 impl WordLen {
+  /// Convert a number into a WordLen.
   pub fn from_u8(val: u8) -> WordLen {
     match val {
       5 => WordLen5bits,
@@ -58,11 +61,14 @@ impl WordLen {
 
 /// Stop bits configuration.
 pub enum StopBit {
+  /// Single stop bit.
   StopBit1bit  = 0b0_00,
+  /// Two stop bits.
   StopBit2bits = 0b1_00,
 }
 
 impl StopBit {
+  /// Convert a number into a StopBit.
   pub fn from_u8(val: u8) -> StopBit {
     match val {
       1 => StopBit1bit,
@@ -107,6 +113,7 @@ enum FIFOTriggerLevel {
   FT14chars = 0b11_00_0_0_0_0,
 }
 
+/// Structure describing a UART instance.
 pub struct UART {
   reg: &'static reg::UART,
   clock: PeripheralClock,
@@ -131,6 +138,7 @@ impl UARTPeripheral {
 }
 
 impl UART {
+  /// Create ans setup a UART.
   pub fn new(peripheral: UARTPeripheral, baudrate: u32, word_len: u8,
       parity: uart::Parity, stop_bits: u8) -> UART {
     let uart = UART {

--- a/src/hal/mem_init.rs
+++ b/src/hal/mem_init.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Helper functions for memory initialisation.
+
 use hal::stack::set_stack_limit;
 
 extern {
@@ -25,12 +27,14 @@ extern {
   static _eglobals: u32;
 }
 
+/// Helper function to initialise the stack limit.
 #[inline(always)]
 pub fn init_stack() {
   set_stack_limit((&_eglobals as *const u32) as u32);
 }
 
-/// Helper function to copy over .data from rom to ram and zero out .bss
+/// Helper function to initialize memory.
+/// Copies `.data` sections in to RAM and initializes `.bss` sections to zero.
 #[inline(always)]
 pub fn init_data() {
   unsafe {

--- a/src/hal/pin.rs
+++ b/src/hal/pin.rs
@@ -13,35 +13,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Common definitions for pin HAL.
+
 /// GPIO direction.
 pub enum GPIODirection {
-  /// Input mode
+  /// Input mode.
   In,
-  /// Output mode
+  /// Output mode.
   Out,
 }
 
 /// Logic levels.
 #[deriving(PartialEq)]
 pub enum GPIOLevel {
-  /// Logic low
+  /// Logic low.
   Low,
-  /// Logic high
+  /// Logic high.
   High,
 }
 
-/// General Purpose I/O
+/// General Purpose I/O.
 pub trait GPIO {
-  /// Set to logic high
+  /// Set to logic high.
   fn set_high(&self);
 
-  /// Set to logic low
+  /// Set to logic low.
   fn set_low(&self);
 
-  /// Read current logic level
+  /// Read current logic level.
   fn level(&self) -> GPIOLevel;
 
   /// Set direction mode to `In` or `Out`,
-  /// for reading or writing respectively
+  /// for reading or writing respectively.
   fn set_direction(&self, new_mode: GPIODirection);
 }

--- a/src/hal/stm32f4/gpio.rs
+++ b/src/hal/stm32f4/gpio.rs
@@ -13,12 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! HAL for STM32F4 GPIO peripheral.
+
 use hal::stm32f4::pin;
 use hal::pin::{GPIODirection};
 
 #[path="../../lib/ioreg.rs"]
 mod ioreg;
 
+/// Configuration for a GPIO.
 pub struct GPIOConf {
   /// Pin configuration for this GPIO.
   pub pin: pin::PinConf,

--- a/src/hal/stm32f4/init.rs
+++ b/src/hal/stm32f4/init.rs
@@ -24,8 +24,6 @@ use core::intrinsics::abort;
 #[path="../../lib/ioreg.rs"] mod ioreg;
 #[path="../../lib/wait_for.rs"] mod wait_for;
 
-pub struct HSI;
-
 /// System clock source.
 pub enum SystemClockSource {
   /// High-speed internal oscillator, 16MHz.
@@ -96,8 +94,8 @@ pub fn apb_low_clock() -> u32 {
   unsafe { APBLowClock }
 }
 
-/// Performs the MCU initialization.
 impl SysConf {
+  /// Performs the MCU initialization.
   pub fn setup(&self) {
     init_data();
     self.clock.setup();
@@ -265,6 +263,7 @@ impl PLLConf {
 // TODO(farcaller): this mod is pub as it's being used in peripheral_clock.rs.
 //                  This is not the best design solution and a good reason to
 //                  split RCC into distinct registers.
+#[allow(missing_doc)]
 pub mod reg {
   use lib::volatile_cell::VolatileCell;
 

--- a/src/hal/stm32f4/mod.rs
+++ b/src/hal/stm32f4/mod.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! HAL for STM32F4.
+
 pub mod pin;
 pub mod init;
 pub mod gpio;

--- a/src/hal/stm32f4/peripheral_clock.rs
+++ b/src/hal/stm32f4/peripheral_clock.rs
@@ -26,6 +26,7 @@ use super::init::reg;
 /// Configures the state of peripheral clock.
 ///
 /// This enum contains all available clocks from both AHB and APB.
+#[allow(missing_doc)]
 pub enum PeripheralClock {
   // AHB1
   GPIOAClock,

--- a/src/hal/stm32f4/pin.rs
+++ b/src/hal/stm32f4/pin.rs
@@ -24,6 +24,7 @@ use core::intrinsics::abort;
 #[path="../../lib/ioreg.rs"] mod ioreg;
 
 /// Available port names.
+#[allow(missing_doc)]
 pub enum Port {
   PortA,
   PortB,
@@ -37,6 +38,7 @@ pub enum Port {
 }
 
 /// Pin functions.
+#[allow(missing_doc)]
 pub enum Function {
   GPIOIn      = 0,
   GPIOOut     = 1,
@@ -74,6 +76,7 @@ pub struct PinConf {
 }
 
 impl PinConf {
+  /// Setup the pin.
   #[no_split_stack]
   #[inline(always)]
   pub fn setup(&self) {

--- a/src/hal/stm32f4/timer.rs
+++ b/src/hal/stm32f4/timer.rs
@@ -15,7 +15,7 @@
 
 //! Timer configuration for ST STM32F4.
 //!
-//! This code supports only TIM2 at the moment
+//! This code supports only TIM2 at the moment.
 
 use super::peripheral_clock;
 use hal::timer;
@@ -23,15 +23,18 @@ use hal::timer;
 #[path="../../lib/ioreg.rs"] mod ioreg;
 
 /// Available timer peripherals.
+#[allow(missing_doc)]
 pub enum TimerPeripheral {
   Timer2,
 }
 
+/// Structure describing a Timer.
 pub struct Timer {
   reg: &'static reg::TIM2To5,
 }
 
 impl Timer {
+  /// Create and start a Timer.
   pub fn new(peripheral: TimerPeripheral, counter: u32) -> Timer {
     let (clock, reg) = match peripheral {
       Timer2 => (peripheral_clock::TIM2Clock, &reg::TIM2),

--- a/src/hal/uart.rs
+++ b/src/hal/uart.rs
@@ -23,9 +23,14 @@ UART objects implement CharIO trait to perform actual data transmission.
 
 /// UART parity mode.
 pub enum Parity {
+  /// Partity disabled.
   Disabled,
+  /// Partity bit added to make number of 1s odd.
   Odd,
+  /// Partity bit added to make number of 1s even.
   Even,
+  /// Partity bit forced to 1.
   Forced1,
+  /// Partity bit forced to 0.
   Forced0,
 }

--- a/src/lib/queue.rs
+++ b/src/lib/queue.rs
@@ -34,7 +34,7 @@ impl<T> Queue<T> {
     }
   }
 
-  /// Push to tail
+  /// Push to tail.
   pub unsafe fn push(&self, node: *mut Node<T>, _: &NoInterrupts) {
     if (*self.head.get()).is_null() {
       *self.head.get() = node;
@@ -47,7 +47,7 @@ impl<T> Queue<T> {
     *self.tail.get() = node;
   }
 
-  /// Peek at head
+  /// Peek at head.
   pub unsafe fn peek(&self) -> Option<*mut Node<T>> {
     let head = self.head.get();
     if (*head).is_null() {
@@ -57,7 +57,7 @@ impl<T> Queue<T> {
     }
   }
 
-  /// Pop off of head
+  /// Pop off of head.
   pub unsafe fn pop(&self, _: &NoInterrupts) -> Option<*mut Node<T>> {
     let head = self.head.get();
     if (*head).is_null() {
@@ -70,7 +70,7 @@ impl<T> Queue<T> {
 }
 
 impl<T: Ord> Queue<T> {
-  /// Priority insertion (higher ends up closer to head)
+  /// Priority insertion (higher ends up closer to head).
   pub unsafe fn insert(&self, node: *mut Node<T>, _: &NoInterrupts) {
     let mut next: &Unsafe<*mut Node<T>> = &self.head;
     loop {

--- a/src/lib/strconv.rs
+++ b/src/lib/strconv.rs
@@ -17,6 +17,7 @@
 
 use core::mem::uninitialized;
 
+/// Convert an integer to a string.
 pub fn itoa(val: u32, buf : &mut [u8], base: u32) {
   let mut rbuf : [u8, ..32] = unsafe { uninitialized() };
   let mut myval : u32 = val;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@
 #![crate_name="zinc"]
 #![crate_type="rlib"]
 #![allow(ctypes)]
-#![warn(missing_doc)]
+#![deny(missing_doc)]
 #![no_std]
 
 /*!
@@ -50,7 +50,7 @@ extern crate rlibc;
 #[cfg(test)] #[phase(plugin,link)] extern crate std;
 #[cfg(test)] extern crate native;
 
-pub mod drivers;
+#[warn(missing_doc)] pub mod drivers;
 pub mod hal;
 pub mod lib;
 pub mod os;

--- a/src/os/cond_var.rs
+++ b/src/os/cond_var.rs
@@ -38,7 +38,7 @@ impl CondVar {
     CondVar { waiting: Queue::new() }
   }
 
-  /// Wait on a condition variable
+  /// Wait on a condition variable.
   pub fn wait<'a>(&'a self) {
     /*
      * The signalling thread is responsible for removing the waiting
@@ -53,7 +53,7 @@ impl CondVar {
     }
   }
 
-  /// Wake up a thread waiting on a condition variable
+  /// Wake up a thread waiting on a condition variable.
   pub fn signal<'a>(&'a self) {
     unsafe {
       let crit = NoInterrupts::new();
@@ -64,7 +64,7 @@ impl CondVar {
     }
   }
 
-  /// Wake up all threads waiting on a condition variable
+  /// Wake up all threads waiting on a condition variable.
   pub fn broadcast<'a>(&'a self) {
     unsafe {
       let crit = NoInterrupts::new();

--- a/src/os/task.rs
+++ b/src/os/task.rs
@@ -23,7 +23,7 @@ use hal::cortex_m3::sched::NoInterrupts;
 use os::syscall::syscall;
 use hal::stack;
 
-/// Task takes one argument, which is u32
+/// Task takes one argument, which is u32.
 pub type Task = fn(u32);
 
 mod current_stack_offset {


### PR DESCRIPTION
Just leaves `drivers` (and `platformtree`) to go.
