### PR TITLE
Move `lib/support.rs` to zinc crate

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,16 +43,6 @@ compile_rust :zinc_crate, {
   recompile_on: [:triple, :platform],
 }
 
-# zinc runtime support lib
-compile_rust :zinc_support, {
-  source:  'lib/support.rs'.in_source,
-  deps:    [:rlibc_crate],
-  produce: 'support.o'.in_intermediate,
-  llvm_pass: :inline,
-  lto: false,
-  recompile_on: :triple,
-}
-
 # zinc isr crate
 compile_rust :zinc_isr, {
   source:  'hal/isr.rs'.in_source,
@@ -125,7 +115,7 @@ app_tasks = Context.instance.applications.map do |a|
 
   link_binary "app_#{a}_elf".to_sym, {
     script: 'layout.ld'.in_platform,
-    deps: ["app_#{a}".to_sym, :zinc_isr, :zinc_support],
+    deps: ["app_#{a}".to_sym, :zinc_isr],
     # TODO(farcaller): broken until implemented in PT.
     # (features.include?(:multitasking) ? [:zinc_isr_sched] : []),
     produce: "app_#{a}.elf".in_build,

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod strconv;
 pub mod volatile_cell;
+pub mod support;
 #[cfg(cfg_multitasking)] pub mod shared;
 #[cfg(cfg_multitasking)] pub mod queue;
 

--- a/src/lib/support.rs
+++ b/src/lib/support.rs
@@ -13,66 +13,47 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_std]
-#![crate_type="rlib"]
-#![feature(asm, intrinsics)]
+//! Support functions currently required by the linker for bare-metal targets.
 
+#[doc(hidden)]
 #[cfg(test)]
 #[no_split_stack]
 #[no_mangle]
-pub fn breakpoint() { unimplemented!() }
+pub extern fn breakpoint() { unimplemented!() }
 
+/// Call the debugger.
 #[cfg(not(test))]
 #[no_split_stack]
 #[no_mangle]
-pub fn breakpoint() {
+pub extern fn breakpoint() {
   unsafe { asm!("bkpt") }
 }
 
+/// Call the debugger and halts execution.
 #[no_split_stack]
 #[no_mangle]
-pub fn abort() -> ! {
+pub extern fn abort() -> ! {
   breakpoint();
   loop {}
 }
 
+#[doc(hidden)]
 #[no_split_stack]
 #[no_mangle]
-pub fn __aeabi_unwind_cpp_pr0() {
+pub extern fn __aeabi_unwind_cpp_pr0() {
   abort();
 }
 
+#[doc(hidden)]
 #[no_split_stack]
 #[no_mangle]
-pub fn __aeabi_unwind_cpp_pr1() {
+pub extern fn __aeabi_unwind_cpp_pr1() {
   abort();
 }
 
+#[doc(hidden)]
 #[no_split_stack]
 #[no_mangle]
-pub fn get_eit_entry() {
-  abort();
-}
-
-#[no_split_stack]
-#[no_mangle]
-pub fn unwind_phase2_forced() {
-  abort();
-}
-
-#[no_split_stack]
-#[no_mangle]
-pub fn unwind_phase2() {
-  abort();
-}
-
-#[no_split_stack]
-#[no_mangle]
-pub unsafe fn rust_fail_bounds_check() {
-  abort();
-}
-#[no_split_stack]
-#[no_mangle]
-pub fn rust_begin_unwind() {
+pub extern fn get_eit_entry() {
   abort();
 }


### PR DESCRIPTION
As discussed in #106, this removes a bunch of functions that are no longer needed and only keeps the ones it doesn't compile with. It's been verified that there no symbols pulled into the ELFs from anywhere that would be the same as the ones removed by this change.
