### PR TITLE
Demonstrate lifting of 'device specific' info

### DIFF
--- a/apps/app_blink_k20.rs
+++ b/apps/app_blink_k20.rs
@@ -6,9 +6,10 @@ extern crate core;
 extern crate zinc;
 
 use core::option::Some;
-use zinc::hal::k20::pin;
 use zinc::hal::pin::GPIO;
 use zinc::hal::cortex_m4::systick;
+
+mod k20dx;
 
 /// Wait the given number of SysTick ticks
 pub fn wait(ticks: u32) {
@@ -33,9 +34,11 @@ pub unsafe fn main() {
   zinc::hal::mem_init::init_stack();
   zinc::hal::mem_init::init_data();
 
-  // Pins for MC HCK (http://www.mchck.org/)
-  let led1 = pin::Pin::new(pin::PortB, 16, pin::GPIO, Some(zinc::hal::pin::Out));
+  let gpio = k20dx::GPIOB::enable();
 
+  // Pins for MC HCK (http://www.mchck.org/)
+  let led1 = gpio.get_pin(16, Some(zinc::hal::pin::Out));
+  
   systick::setup(480000, false);
   systick::enable();
   loop {

--- a/apps/k20dx.rs
+++ b/apps/k20dx.rs
@@ -1,0 +1,23 @@
+use core::mem::transmute;
+use zinc::hal::k20::pin::GPIO;
+use zinc::hal::k20::sim::reg::SIM;
+
+fn get_sim() -> &'static SIM {
+  unsafe { transmute(0x40047000 as *mut ()) }
+}
+
+pub struct GPIOB;
+
+impl GPIOB {
+  pub fn enable() -> GPIO {
+    let sim = get_sim();
+    
+    sim.set_SCGC5(sim.SCGC5() | (1 << 10));
+    
+    unsafe {
+      GPIO::new(
+        transmute(0x400FF040 as *mut ()),
+        transmute(0x4004A000 as *mut ())) 
+    }
+  }
+}

--- a/src/hal/k20/pin.rs
+++ b/src/hal/k20/pin.rs
@@ -22,27 +22,33 @@ on the package.
 
 use core::option::Option;
 
-use lib::volatile_cell::VolatileCell;
-
-use super::sim;
-
 #[path="../../lib/ioreg.rs"] mod ioreg;
+
+/// A GPIO bank
+#[allow(missing_doc)]
+pub struct GPIO {
+  gpio: &'static reg::GPIO,
+  port: &'static reg::PORT,
+}
+
+impl GPIO {
+  /// Returns a GPIO bank instance.
+  pub fn new(gpio: &'static reg::GPIO, port: &'static reg::PORT) -> GPIO {
+    GPIO { gpio: gpio, port: port }
+  }
+
+  /// Returns a Pin to control the the requested pin.
+  pub fn get_pin(&self, pin: u8,
+                 gpiodir: Option<::hal::pin::GPIODirection>) -> Pin {
+    Pin::new(self.gpio, self.port, pin, Gpio, gpiodir)
+  }
+}
 
 /// A pin.
 #[allow(missing_doc)]
 pub struct Pin {
-  pub port: Port,
-  pub pin: u8,
-}
-
-/// Available port names.
-#[allow(missing_doc)]
-pub enum Port {
-  PortA = 1,
-  PortB = 2,
-  PortC = 3,
-  PortD = 4,
-  PortE = 5,
+  gpio: &'static reg::GPIO,
+  pin: u8,
 }
 
 /// Pin functions (GPIO or up to seven additional functions).
@@ -50,7 +56,7 @@ pub enum Port {
 #[allow(missing_doc)]
 pub enum Function {
   Analog       = 0,
-  GPIO         = 1,
+  Gpio        = 1,
   AltFunction2 = 2,
   AltFunction3 = 3,
   AltFunction4 = 4,
@@ -83,24 +89,23 @@ pub enum SlewRate {
 
 impl Pin {
   /// Create and setup a Pin.
-  pub fn new(port: Port, pin_index: u8, function: Function,
-      gpiodir: Option<::hal::pin::GPIODirection>) -> Pin {
+  pub fn new(gpio: &'static reg::GPIO, port: &'static reg::PORT,
+             pin_index: u8, function: Function, 
+             gpiodir: Option<::hal::pin::GPIODirection>) -> Pin {
     let pin = Pin {
-      port: port,
+      gpio: gpio,
       pin: pin_index,
     };
-    pin.setup_regs(function, gpiodir, PullNone,
+    pin.setup_regs(port, function, gpiodir, PullNone,
                    DriveStrengthHigh, SlewSlow, false, false);
 
     pin
   }
 
-  fn setup_regs(&self, function: Function,
+  fn setup_regs(&self, port: &'static reg::PORT, function: Function,
       gpiodir: Option<::hal::pin::GPIODirection>,
       pull: PullConf, drive_strength: DriveStrength,
       slew_rate: SlewRate, filter: bool, open_drain: bool) {
-    // enable port clock
-    sim::enable_PORT(self.port as uint);
 
     let value =
           (pull as u32 << 0)
@@ -109,54 +114,33 @@ impl Pin {
           | (open_drain as u32 << 5)
           | (drive_strength as u32 << 6)
           | (function as u32 << 8);
-    self.pcr().set(value);
+    port.PCR[self.pin as uint].set(value);
 
-    if function == GPIO {
+    if function == Gpio {
       (self as &::hal::pin::GPIO).set_direction(gpiodir.unwrap());
-    }
-  }
-
-  fn gpioreg(&self) -> &reg::GPIO {
-    match self.port {
-      PortA => &reg::GPIOA,
-      PortB => &reg::GPIOB,
-      PortC => &reg::GPIOC,
-      PortD => &reg::GPIOD,
-      PortE => &reg::GPIOE,
     }
   }
 
   fn gpiobit(&self) -> u32 {
     1 << (self.pin as uint)
   }
-
-  fn pcr(&self) -> &VolatileCell<u32> {
-    let port: &reg::PORT = match self.port {
-      PortA => &reg::PORTA,
-      PortB => &reg::PORTB,
-      PortC => &reg::PORTC,
-      PortD => &reg::PORTD,
-      PortE => &reg::PORTE,
-    };
-    return &port.PCR[self.pin as uint];
-  }
 }
 
 impl ::hal::pin::GPIO for Pin {
   /// Sets output GPIO value to high.
   fn set_high(&self) {
-    self.gpioreg().set_PSOR(self.gpiobit());
+    self.gpio.set_PSOR(self.gpiobit());
   }
 
   /// Sets output GPIO value to low.
   fn set_low(&self) {
-    self.gpioreg().set_PCOR(self.gpiobit());
+    self.gpio.set_PCOR(self.gpiobit());
   }
 
   /// Returns input GPIO level.
   fn level(&self) -> ::hal::pin::GPIOLevel {
     let bit: u32 = self.gpiobit();
-    let reg = self.gpioreg();
+    let reg = self.gpio;
 
     match reg.PDIR() & bit {
       0 => ::hal::pin::Low,
@@ -167,7 +151,7 @@ impl ::hal::pin::GPIO for Pin {
   /// Sets output GPIO direction.
   fn set_direction(&self, new_mode: ::hal::pin::GPIODirection) {
     let bit: u32 = self.gpiobit();
-    let reg = self.gpioreg();
+    let reg = self.gpio;
     let val: u32 = reg.PDDR();
     let new_val: u32 = match new_mode {
       ::hal::pin::In  => val & !bit,
@@ -178,7 +162,8 @@ impl ::hal::pin::GPIO for Pin {
   }
 }
 
-mod reg {
+#[allow(missing_doc)]
+pub mod reg {
   use lib::volatile_cell::VolatileCell;
 
   #[allow(uppercase_variables)]
@@ -192,14 +177,6 @@ mod reg {
     pub DFWR: VolatileCell<u32>,
   }
 
-  extern {
-    #[link_name="k20_iomem_PORTA"] pub static PORTA: PORT;
-    #[link_name="k20_iomem_PORTB"] pub static PORTB: PORT;
-    #[link_name="k20_iomem_PORTC"] pub static PORTC: PORT;
-    #[link_name="k20_iomem_PORTD"] pub static PORTD: PORT;
-    #[link_name="k20_iomem_PORTE"] pub static PORTE: PORT;
-  }
-
   ioreg!(GPIO: u32, PDOR, PSOR, PCOR, PTOR, PDIR, PDDR)
   reg_rw!(GPIO, u32, PDOR,  set_PDOR,  PDOR)
   reg_rw!(GPIO, u32, PSOR,  set_PSOR,  PSOR)
@@ -207,12 +184,4 @@ mod reg {
   reg_rw!(GPIO, u32, PTOR,  set_PTOR,  PTOR)
   reg_rw!(GPIO, u32, PDIR,  set_PDIR,  PDIR)
   reg_rw!(GPIO, u32, PDDR,  set_PDDR,  PDDR)
-
-  extern {
-    #[link_name="k20_iomem_GPIOA"] pub static GPIOA: GPIO;
-    #[link_name="k20_iomem_GPIOB"] pub static GPIOB: GPIO;
-    #[link_name="k20_iomem_GPIOC"] pub static GPIOC: GPIO;
-    #[link_name="k20_iomem_GPIOD"] pub static GPIOD: GPIO;
-    #[link_name="k20_iomem_GPIOE"] pub static GPIOE: GPIO;
-  }
 }

--- a/src/hal/k20/sim.rs
+++ b/src/hal/k20/sim.rs
@@ -24,11 +24,12 @@ pub fn enable_PORT(num: uint) {
 }
 
 #[allow(dead_code)]
-mod reg {
+#[allow(missing_doc)]
+pub mod reg {
   use lib::volatile_cell::VolatileCell;
 
   #[allow(uppercase_variables)]
-  struct SIM {
+  pub struct SIM {
     SOPT1:    VolatileCell<u32>,
     SOPT1CFG: VolatileCell<u32>,
     _pad0:    [VolatileCell<u32>, ..(0x1004 - 0x8) / 4],


### PR DESCRIPTION
To enable bootstrapping of Zinc, much information has been put at the
HAL level. An incomplete list of information is:
- ARM register definition
- ARM register memory location
- Vendor register definition
- Vendor register memory location
- Register abstraction accessors

The vendor memory locations should be lifted out into a device specific
module, which is ideally generated from a memory map. This simplifies
management of different memory maps and peripheral availability between
devices of the same vendor family.

A selection of these device specific modules should be cultivated in
the contrib directory.
