### PR TITLE
Move the `ioreg!` macro to `ioreg_old!`

### DIFF
--- a/src/hal/cortex_common/mpu.rs
+++ b/src/hal/cortex_common/mpu.rs
@@ -21,7 +21,7 @@
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(MPUReg: u32, TYPE, CTRL, RNR, RBAR, RASR)
+  ioreg_old!(MPUReg: u32, TYPE, CTRL, RNR, RBAR, RASR)
   reg_r!( MPUReg, u32, TYPE,                     TYPE)
   reg_rw!(MPUReg, u32, CTRL,     set_CTRL,       CTRL)
   reg_rw!(MPUReg, u32, RNR,      set_RNR,        RNR)

--- a/src/hal/cortex_common/nvic.rs
+++ b/src/hal/cortex_common/nvic.rs
@@ -21,7 +21,7 @@
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(ISERReg: u32, ISER0, ISER1, ISER2, ISER3,
+  ioreg_old!(ISERReg: u32, ISER0, ISER1, ISER2, ISER3,
         ISER4, ISER5, ISER6, ISER7)
   reg_rw!(ISERReg, u32, ISER0,   set_ISER0,      ISER0)
   reg_rw!(ISERReg, u32, ISER1,   set_ISER1,      ISER1)
@@ -32,7 +32,7 @@ mod reg {
   reg_rw!(ISERReg, u32, ISER6,   set_ISER6,      ISER6)
   reg_rw!(ISERReg, u32, ISER7,   set_ISER7,      ISER7)
 
-  ioreg!(ICERReg: u32, ICER0, ICER1, ICER2, ICER3,
+  ioreg_old!(ICERReg: u32, ICER0, ICER1, ICER2, ICER3,
         ICER4, ICER5, ICER6, ICER7)
   reg_rw!(ICERReg, u32, ICER0,   set_ICER0,      ICER0)
   reg_rw!(ICERReg, u32, ICER1,   set_ICER1,      ICER1)
@@ -43,7 +43,7 @@ mod reg {
   reg_rw!(ICERReg, u32, ICER6,   set_ICER6,      ICER6)
   reg_rw!(ICERReg, u32, ICER7,   set_ICER7,      ICER7)
 
-  ioreg!(ISPRReg: u32, ISPR0, ISPR1, ISPR2, ISPR3,
+  ioreg_old!(ISPRReg: u32, ISPR0, ISPR1, ISPR2, ISPR3,
         ISPR4, ISPR5, ISPR6, ISPR7)
   reg_rw!(ISPRReg, u32, ISPR0,   set_ISPR0,      ISPR0)
   reg_rw!(ISPRReg, u32, ISPR1,   set_ISPR1,      ISPR1)
@@ -54,7 +54,7 @@ mod reg {
   reg_rw!(ISPRReg, u32, ISPR6,   set_ISPR6,      ISPR6)
   reg_rw!(ISPRReg, u32, ISPR7,   set_ISPR7,      ISPR7)
 
-  ioreg!(ICPRReg: u32, ICPR0, ICPR1, ICPR2, ICPR3,
+  ioreg_old!(ICPRReg: u32, ICPR0, ICPR1, ICPR2, ICPR3,
         ICPR4, ICPR5, ICPR6, ICPR7)
   reg_rw!(ICPRReg, u32, ICPR0,   set_ICPR0,      ICPR0)
   reg_rw!(ICPRReg, u32, ICPR1,   set_ICPR1,      ICPR1)
@@ -65,7 +65,7 @@ mod reg {
   reg_rw!(ICPRReg, u32, ICPR6,   set_ICPR6,      ICPR6)
   reg_rw!(ICPRReg, u32, ICPR7,   set_ICPR7,      ICPR7)
 
-  ioreg!(IABRReg: u32, IABR0, IABR1, IABR2, IABR3,
+  ioreg_old!(IABRReg: u32, IABR0, IABR1, IABR2, IABR3,
         IABR4, IABR5, IABR6, IABR7)
   reg_rw!(IABRReg, u32, IABR0,   set_IABR0,      IABR0)
   reg_rw!(IABRReg, u32, IABR1,   set_IABR1,      IABR1)
@@ -77,10 +77,10 @@ mod reg {
   reg_rw!(IABRReg, u32, IABR7,   set_IABR7,      IABR7)
 
   //TODO(bharrisau): Implement byte-level access for 240 Priority Registers
-  ioreg!(IPRReg: u32, IPR0)
+  ioreg_old!(IPRReg: u32, IPR0)
   reg_w!(IPRReg, u32, set_IPR0, IPR0)
 
-  ioreg!(STIRReg: u32, STIR)
+  ioreg_old!(STIRReg: u32, STIR)
   reg_w!(STIRReg, u32, set_STIR, STIR)
 
   #[allow(dead_code)]

--- a/src/hal/cortex_common/scb.rs
+++ b/src/hal/cortex_common/scb.rs
@@ -36,10 +36,10 @@ pub fn set_pendsv(val: bool) {
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(SCBACTLRReg: u32, ACTLR)
+  ioreg_old!(SCBACTLRReg: u32, ACTLR)
   reg_rw!(SCBACTLRReg, u32, ACTLR, set_ACTLR, ACTLR)
 
-  ioreg!(SCBReg: u32, CPUID, ICSR, VTOR, AIRCR, SCR, CCR, SHPR1, SHPR2,
+  ioreg_old!(SCBReg: u32, CPUID, ICSR, VTOR, AIRCR, SCR, CCR, SHPR1, SHPR2,
          SHPR3, SHCRS, CFSR, HFSR, _pad_0, MMAR, BFAR, AFSR)
   reg_r!( SCBReg, u32, CPUID,                    CPUID)
   reg_rw!(SCBReg, u32, ICSR,     set_ICSR,       ICSR)

--- a/src/hal/cortex_common/systick.rs
+++ b/src/hal/cortex_common/systick.rs
@@ -70,7 +70,7 @@ pub fn tick() -> bool {
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(SYSTICKReg: u32, CONTROL, RELOAD, CURRENT, CALIBRATION)
+  ioreg_old!(SYSTICKReg: u32, CONTROL, RELOAD, CURRENT, CALIBRATION)
   reg_rw!(SYSTICKReg, u32, CONTROL,     set_CONTROL, CONTROL)
   reg_rw!(SYSTICKReg, u32, RELOAD,      set_RELOAD,  RELOAD)
   reg_rw!(SYSTICKReg, u32, CURRENT,     set_CURRENT, CURRENT)

--- a/src/hal/k20/pin.rs
+++ b/src/hal/k20/pin.rs
@@ -200,7 +200,7 @@ mod reg {
     #[link_name="k20_iomem_PORTE"] pub static PORTE: PORT;
   }
 
-  ioreg!(GPIO: u32, PDOR, PSOR, PCOR, PTOR, PDIR, PDDR)
+  ioreg_old!(GPIO: u32, PDOR, PSOR, PCOR, PTOR, PDIR, PDDR)
   reg_rw!(GPIO, u32, PDOR,  set_PDOR,  PDOR)
   reg_rw!(GPIO, u32, PSOR,  set_PSOR,  PSOR)
   reg_rw!(GPIO, u32, PCOR,  set_PCOR,  PCOR)

--- a/src/hal/k20/uart.rs
+++ b/src/hal/k20/uart.rs
@@ -162,7 +162,7 @@ static PFIFORxFifoEnabled: u8 = 0b0000_1000;
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(UART: u8, BDH, BDL, C1, C2, S1, S2, C3, D, MA1, MA2, C4, C5, ED, MODEM, IR,
+  ioreg_old!(UART: u8, BDH, BDL, C1, C2, S1, S2, C3, D, MA1, MA2, C4, C5, ED, MODEM, IR,
          PFIFO, CFIFO, SFIFO, TWFIFO, TCFIFO, RWFIFO, RCFIFO)
   reg_rw!(UART, u8, BDH,     set_BDH,     BDH)
   reg_rw!(UART, u8, BDL,     set_BDL,     BDL)

--- a/src/hal/lpc17xx/peripheral_clock.rs
+++ b/src/hal/lpc17xx/peripheral_clock.rs
@@ -214,10 +214,10 @@ impl PeripheralClock {
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(PCONP: u32, value)
+  ioreg_old!(PCONP: u32, value)
   reg_rw!(PCONP, u32, value, set_value, value)
 
-  ioreg!(PCLKSEL: u32, value)
+  ioreg_old!(PCLKSEL: u32, value)
   reg_rw!(PCLKSEL, u32, value, set_value, value)
 
   extern {

--- a/src/hal/lpc17xx/pin.rs
+++ b/src/hal/lpc17xx/pin.rs
@@ -166,7 +166,7 @@ pub fn set_trace_port_interface_enabled(enabled: bool) {
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(PINSEL: u32, value)
+  ioreg_old!(PINSEL: u32, value)
   reg_rw!(PINSEL, u32, value, set_value, value)
 
   extern {
@@ -180,7 +180,7 @@ mod reg {
     #[link_name="lpc17xx_iomem_PINSEL10"] pub static PINSEL10: PINSEL;
   }
 
-  ioreg!(GPIO: u32, FIODIR, _r0, _r1, _r2, FIOMASK, FIOPIN, FIOSET, FIOCLR)
+  ioreg_old!(GPIO: u32, FIODIR, _r0, _r1, _r2, FIOMASK, FIOPIN, FIOSET, FIOCLR)
   reg_rw!(GPIO, u32, FIODIR,  set_FIODIR,  FIODIR)
   reg_rw!(GPIO, u32, FIOMASK, set_FIOMASK, FIOMASK)
   reg_rw!(GPIO, u32, FIOPIN,  set_FIOPIN,  FIOPIN)

--- a/src/hal/lpc17xx/ssp.rs
+++ b/src/hal/lpc17xx/ssp.rs
@@ -226,7 +226,7 @@ impl spi::SPI for SSP {
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(SSP: u32, CR0, CR1, DR, SR, CPSR, IMSC, RIS, MIS, ICR, DMACR)
+  ioreg_old!(SSP: u32, CR0, CR1, DR, SR, CPSR, IMSC, RIS, MIS, ICR, DMACR)
   reg_rw!(SSP, u32, CR0,   set_CR0,   CR0)
   reg_rw!(SSP, u32, CR1,   set_CR1,   CR1)
   reg_rw!(SSP, u32, DR,    set_DR,    DR)

--- a/src/hal/lpc17xx/system_clock.rs
+++ b/src/hal/lpc17xx/system_clock.rs
@@ -152,21 +152,21 @@ fn init_pll(pll: &PLL0, source: ClockSource) {
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(SCS: u32, value)
+  ioreg_old!(SCS: u32, value)
   reg_rw!(SCS, u32, value, set_value, value)
-  ioreg!(FLASHCFG: u32, value)
+  ioreg_old!(FLASHCFG: u32, value)
   reg_w!(FLASHCFG, u32, set_value, value)
-  ioreg!(PLL0CFG: u32, value)
+  ioreg_old!(PLL0CFG: u32, value)
   reg_w!(PLL0CFG, u32, set_value, value)
-  ioreg!(PLL0CON: u32, value)
+  ioreg_old!(PLL0CON: u32, value)
   reg_w!(PLL0CON, u32, set_value, value)
-  ioreg!(PLL0FEED: u32, value)
+  ioreg_old!(PLL0FEED: u32, value)
   reg_w!(PLL0FEED, u32, set_value, value)
-  ioreg!(PLL0STAT: u32, value)
+  ioreg_old!(PLL0STAT: u32, value)
   reg_r!(PLL0STAT, u32, value, value)
-  ioreg!(CCLKCFG: u32, value)
+  ioreg_old!(CCLKCFG: u32, value)
   reg_w!(CCLKCFG, u32, set_value, value)
-  ioreg!(CLKSRCSEL: u32, value)
+  ioreg_old!(CLKSRCSEL: u32, value)
   reg_w!(CLKSRCSEL, u32, set_value, value)
 
   extern {

--- a/src/hal/lpc17xx/timer.rs
+++ b/src/hal/lpc17xx/timer.rs
@@ -82,7 +82,7 @@ impl timer::Timer for Timer {
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(TIMER: u32, IR, TCR, TC, PR, PC, MCR, MR0, MR1, MR2, MR3, CCR, CR0, CR1, EMR, CTCR)
+  ioreg_old!(TIMER: u32, IR, TCR, TC, PR, PC, MCR, MR0, MR1, MR2, MR3, CCR, CR0, CR1, EMR, CTCR)
   reg_rw!(TIMER, u32, IR,  set_IR,  IR)
   reg_rw!(TIMER, u32, TCR, set_TCR, TCR)
   reg_rw!(TIMER, u32, TC, set_TC, TC)

--- a/src/hal/lpc17xx/uart.rs
+++ b/src/hal/lpc17xx/uart.rs
@@ -281,7 +281,7 @@ static LSRTHREmpty: u8 = 0x20;
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(UART: u32, RBR_THR_DLL, DLM_IER, IIR_FCR, LCR, _pad_0, LSR, _pad_1, SCR, ACR, ICR, FDR, _pad_2, TER)
+  ioreg_old!(UART: u32, RBR_THR_DLL, DLM_IER, IIR_FCR, LCR, _pad_0, LSR, _pad_1, SCR, ACR, ICR, FDR, _pad_2, TER)
   reg_r!( UART, u32, RBR,          RBR_THR_DLL)
   reg_w!( UART, u32,      set_THR, RBR_THR_DLL)
   reg_rw!(UART, u32, DLL, set_DLL, RBR_THR_DLL)

--- a/src/hal/stm32f4/init.rs
+++ b/src/hal/stm32f4/init.rs
@@ -273,7 +273,7 @@ pub mod reg {
     SystemClockPLL = 2,
   }
 
-  ioreg!(RCCReg: u32, CR, PLLCFGR, CFGR, CIR, AHB1RSTR, AHB2RSTR, AHB3RSTR,
+  ioreg_old!(RCCReg: u32, CR, PLLCFGR, CFGR, CIR, AHB1RSTR, AHB2RSTR, AHB3RSTR,
                       _pad_0, APB1RSTR, APB2RSTR, _pad_1, _pad_2, AHB1ENR,
                       AHB2ENR, AHB3ENR, _pad_3, APB1ENR, APB2ENR, _pad_4,
                       _pad_5, AHB1LPENR, AHB2LPENR, AHB3LPENR, _pad_6,
@@ -303,7 +303,7 @@ pub mod reg {
   reg_rw!(RCCReg, u32, SSCGR,      set_SSCGR,      SSCGR)
   reg_rw!(RCCReg, u32, PLLI2SCFGR, set_PLLI2SCFGR, PLLI2SCFGR)
 
-  ioreg!(FLASHReg: u32, ACR, KEYR, OPTKEYR, SR, CR, OPTCR)
+  ioreg_old!(FLASHReg: u32, ACR, KEYR, OPTKEYR, SR, CR, OPTCR)
   reg_rw!(FLASHReg, u32, ACR,   set_ACR,     ACR)
   reg_w!(FLASHReg,  u32,        set_KEYR,    KEYR)
   reg_w!(FLASHReg,  u32,        set_OPTKEYR, OPTKEYR)
@@ -311,7 +311,7 @@ pub mod reg {
   reg_rw!(FLASHReg, u32, CR,    set_CR,      CR)
   reg_rw!(FLASHReg, u32, OPTCR, set_OPTCR,   OPTCR)
 
-  ioreg!(PWRReg: u32, CR, CSR)
+  ioreg_old!(PWRReg: u32, CR, CSR)
   reg_rw!(PWRReg, u32, CR,  set_CR,  CR)
   reg_rw!(PWRReg, u32, CSR, set_CSR, CSR)
 

--- a/src/hal/stm32f4/pin.rs
+++ b/src/hal/stm32f4/pin.rs
@@ -138,7 +138,7 @@ impl PinConf {
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(GPIO: u32, MODER, OTYPER, OSPEEDER, PUPDR, IDR, ODR, BSRR, LCKR, AFRL, AFRH)
+  ioreg_old!(GPIO: u32, MODER, OTYPER, OSPEEDER, PUPDR, IDR, ODR, BSRR, LCKR, AFRL, AFRH)
   reg_rw!(GPIO, u32, MODER,    set_MODER,    MODER)
   reg_rw!(GPIO, u32, OTYPER,   set_OTYPER,   OTYPER)
   reg_rw!(GPIO, u32, OSPEEDER, set_OSPEEDER, OSPEEDER)

--- a/src/hal/stm32f4/timer.rs
+++ b/src/hal/stm32f4/timer.rs
@@ -62,7 +62,7 @@ impl timer::Timer for Timer {
 mod reg {
   use lib::volatile_cell::VolatileCell;
 
-  ioreg!(TIM2To5: u32, CR1, CR2, SMCR, DIER, SR, EGR, CCMR1, CCMR2, CCER, CNT,
+  ioreg_old!(TIM2To5: u32, CR1, CR2, SMCR, DIER, SR, EGR, CCMR1, CCMR2, CCER, CNT,
                        PSC, ARR, _pad_0, CCR1, CCR2, CCR3, CCR4, _pad_1, DCR,
                        DMAR, OR)
   reg_rw!(TIM2To5, u32, CR1,   set_CR1,   CR1)

--- a/src/lib/ioreg.rs
+++ b/src/lib/ioreg.rs
@@ -15,7 +15,7 @@
 
 #![macro_escape]
 
-macro_rules! ioreg(
+macro_rules! ioreg_old(
   ($io:ident: $ty:ty, $($reg:ident),+) => (
     #[allow(uppercase_variables)]
     pub struct $io {

--- a/src/lib/volatile_cell.rs
+++ b/src/lib/volatile_cell.rs
@@ -19,7 +19,7 @@ use core::kinds::marker;
 use core::intrinsics::{volatile_load, volatile_store};
 
 /// This structure is used to represent a hardware register.
-/// It is mostly used by `ioreg!` macro.
+/// It is mostly used by the ioreg family of macros.
 pub struct VolatileCell<T> {
   value: T,
   invariant: marker::InvariantType<T>,


### PR DESCRIPTION
Indentation alignment isn't corrected, but the `_old` suffix is ugly
anyway.
