### PR TITLE
systick: Refactoring.

### DIFF
--- a/apps/app_blink_k20.rs
+++ b/apps/app_blink_k20.rs
@@ -37,7 +37,7 @@ pub unsafe fn main() {
   // Pins for MC HCK (http://www.mchck.org/)
   let led1 = pin::Pin::new(pin::PortB, 16, pin::GPIO, Some(zinc::hal::pin::Out));
 
-  systick::setup(480000, false);
+  systick::setup(systick::ten_ms().unwrap_or(480000));
   systick::enable();
   loop {
     led1.set_high();

--- a/apps/old_app_systick.rs
+++ b/apps/old_app_systick.rs
@@ -40,7 +40,7 @@ unsafe fn systick_handler() {
 #[no_split_stack]
 pub fn main() {
   platform.configuration.setup();
-  systick::setup(systick::CALIBRATED, true);
+  systick::setup(systick::ten_ms().unwrap_or(480000));
 
   let led1 = platform.led1.setup();
 
@@ -48,6 +48,7 @@ pub fn main() {
 
   let mut ison: bool = true;
 
+  systick::enable_irq();
   systick::enable();
 
   unsafe { loop {


### PR DESCRIPTION
This change rewrites systick module a bit to use new ioreg macro, changes  `systick::setup` a bit to eliminate "boolean trap", exposes tenms() to the user, so the user can read and manipulate it.
