### PR TITLE
Do not depend on a triple for system libs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,6 @@ compile_rust :rlibc_crate, {
   source:  'thirdparty/librlibc/lib.rs'.in_root,
   produce: 'thirdparty/librlibc/lib.rs'.in_root.as_rlib.in_build,
   out_dir: true,
-  recompile_on: :triple,
 }
 
 # cross-compiled libcore
@@ -40,7 +39,6 @@ compile_rust :core_crate, {
   source:  'thirdparty/libcore/lib.rs'.in_root,
   produce: 'thirdparty/libcore/lib.rs'.in_root.as_rlib.in_build,
   out_dir: true,
-  recompile_on: :triple,
 }
 
 # ioreg


### PR DESCRIPTION
While this is regression, technically, I'm moving the code away from depending on system libs, those should be provided externally.

This doesn't break anything in build system as zinc currently works on one triple anyway.