### PR TITLE
Add debug tracing module

### DIFF
--- a/src/zinc/os/mod.rs
+++ b/src/zinc/os/mod.rs
@@ -25,3 +25,4 @@ pub mod syscall;
 #[cfg(cfg_multitasking)] pub mod task;
 pub mod mutex;
 pub mod cond_var;
+pub mod debug;


### PR DESCRIPTION
This provides a single point for a user to specify a debug logging target.
