### PR TITLE
hal: k20 - flash config section addition

### DIFF
--- a/src/zinc/hal/k20/isr.rs
+++ b/src/zinc/hal/k20/isr.rs
@@ -88,6 +88,15 @@ extern {
   fn isr_soft();
 }
 
+#[link_section=".flash_configuration"]
+#[allow(non_upper_case_globals)]
+pub static FlashConfigField: [uint, ..4] = [
+    0xFFFFFFFF,
+    0xFFFFFFFF,
+    0xFFFFFFFF,
+    0xFFFFFFFE,
+];
+
 #[allow(non_upper_case_globals)]
 const ISRCount: uint = 95;
 

--- a/src/zinc/hal/k20/layout.ld
+++ b/src/zinc/hal/k20/layout.ld
@@ -20,7 +20,69 @@ MEMORY
 }
 
 REGION_ALIAS("vectors", VECT);
+REGION_ALIAS("flash_config", FCFG)
 REGION_ALIAS("rom", FLASH);
 REGION_ALIAS("ram", RAM);
 
-INCLUDE ./src/zinc/hal/layout_common.ld
+SECTIONS
+{
+    .vector : ALIGN(4)
+    {
+        FILL(0xff)
+
+        KEEP(*(.isr_vector))
+        KEEP(*(.isr_vector_nvic))
+    } > vectors
+
+    .flashcfg : ALIGN(4)
+    {
+        KEEP(*(.flash_configuration))
+    } > flash_config
+
+    .text : ALIGN(4)
+    {
+        FILL(0xff)
+        *(.text*)
+        *(.rodata .rodata.*)
+    } > rom
+
+    .data : ALIGN(4)
+    {
+        _data = .;
+
+        *(SORT_BY_ALIGNMENT(.data*))
+        . = ALIGN(4);
+
+        _edata = .;
+    } > ram AT>rom = 0xff
+
+    .bss : ALIGN(4)
+    {
+        _bss = .;
+
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+
+        _ebss = .;
+
+        . += 4;
+
+        __STACK_LIMIT = .;
+
+        . += 4;
+
+        _eglobals = .;
+    } > ram
+
+    /DISCARD/ :
+    {
+        *(.glue_7*)  /* arm-thumb interworking */
+        *(.v4_bx)  /* ARMv4 interworking fixup for missing BX */
+        *(.vfp11_veneer)  /* VFP11 bugfixes s.a. http://sourceware.org/ml/binutils/2006-12/msg00196.html */
+        *(.iplt .igot.plt)  /* STT_GNU_IFUNC symbols */
+        *(.rel.*)  /* dynamic relocations */
+        *(.ARM.exidx*) /* exception handling */
+    }
+}
+


### PR DESCRIPTION
This is as I described in #212. Tested with pyOCD and binary mbed cmsis-dap interface (binary flashing)
