### PR TITLE
Build Zinc with Cargo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+target/
 /build/
 /thirdparty/
 .DS_Store
+Cargo.lock
+*.map

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "zinc"
+version = "0.0.1"
+authors = ["farcaller@gmail.com"]
+#build = ["rake target_deps", "support/cargo_deps"]
+
+[lib]
+name = "zinc"
+path = "src/zinc/lib.rs"
+
+[dependencies.rlibc]
+git = "https://github.com/bharrisau/rust-librlibc.git"
+
+[dependencies.core]
+git = "https://github.com/bharrisau/rust-libcore.git"
+
+[dependencies.ioreg]
+path = "src/ioreg"
+
+[dev-dependencies.hamcrest]
+git = "https://github.com/carllerche/hamcrest-rust.git"

--- a/apps/k20/Cargo.toml
+++ b/apps/k20/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "empty"
+version = "0.0.1"
+authors = ["Ben Harris <mail@bharr.is>"]
+
+[dependencies.core]
+git = "https://github.com/bharrisau/rust-libcore.git"
+
+[dependencies.zinc]
+path = "../.."
+
+[[bin]]
+name = "empty"
+path = "src/empty.rs"

--- a/apps/k20/layout.ld
+++ b/apps/k20/layout.ld
@@ -1,0 +1,25 @@
+/* FIXME(bgamari): Make stack base configurable? */
+__STACK_BASE  = 0x20001FFF;
+
+_boot_checksum = 0;
+
+_data_load = LOADADDR(.data);
+
+
+ENTRY(main)
+
+/* For MK20DX32 */
+MEMORY
+{
+    VECT (R)      : ORIGIN = 0x00000000, LENGTH = 0x3FC  /* Vector area */
+    FIRC (R)      : ORIGIN = 0x000003FC, LENGTH = 4      /* Custom IRC user trim */
+    FCFG (R)      : ORIGIN = 0x00000400, LENGTH = 16     /* Flash config */
+    FLASH (RX)    : ORIGIN = 0x00000410, LENGTH = 32K - 0x410
+    RAM (WAIL)    : ORIGIN = 0x20000000 - 8K / 2, LENGTH = 8K
+}
+
+REGION_ALIAS("vectors", VECT);
+REGION_ALIAS("rom", FLASH);
+REGION_ALIAS("ram", RAM);
+
+INCLUDE layout_common.ld

--- a/apps/k20/layout_common.ld
+++ b/apps/k20/layout_common.ld
@@ -1,0 +1,56 @@
+SECTIONS
+{
+    .vector : ALIGN(4)
+    {
+        FILL(0xff)
+
+        KEEP(*(.isr_vector))
+        KEEP(*(.isr_vector_nvic))
+    } > vectors
+
+    .text : ALIGN(4)
+    {
+        FILL(0xff)
+        *(.text*)
+        *(.rodata .rodata.*)
+    } > rom
+
+    .data : ALIGN(4)
+    {
+        _data = .;
+
+        *(SORT_BY_ALIGNMENT(.data*))
+        . = ALIGN(4);
+
+        _edata = .;
+    } > ram AT>rom = 0xff
+
+    .bss : ALIGN(4)
+    {
+        _bss = .;
+
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+
+        _ebss = .;
+
+        . += 4;
+
+        __STACK_LIMIT = .;
+
+        . += 4;
+
+        _eglobals = .;
+    } > ram
+
+    /DISCARD/ :
+    {
+        *(.glue_7*)  /* arm-thumb interworking */
+        *(.v4_bx)  /* ARMv4 interworking fixup for missing BX */
+        *(.vfp11_veneer)  /* VFP11 bugfixes s.a. http://sourceware.org/ml/binutils/2006-12/msg00196.html */
+        *(.iplt .igot.plt)  /* STT_GNU_IFUNC symbols */
+        *(.rel.*)  /* dynamic relocations */
+        *(.ARM.exidx*) /* exception handling */
+    }
+}

--- a/apps/k20/src/empty.rs
+++ b/apps/k20/src/empty.rs
@@ -1,0 +1,22 @@
+#![feature(asm, linkage)]
+#![no_std]
+#![no_main]
+
+extern crate core;
+extern crate zinc;
+
+pub mod mk20_dx256_vlh7;
+
+#[no_mangle]
+pub unsafe extern fn main() {
+  zinc::hal::mem_init::init_stack();
+  zinc::hal::mem_init::init_data();
+  run();
+
+  loop {};
+}
+
+fn run() {
+  unsafe { asm!("nop") }
+}
+

--- a/apps/k20/src/mk20_dx256_vlh7.rs
+++ b/apps/k20/src/mk20_dx256_vlh7.rs
@@ -1,0 +1,148 @@
+use core::option::{Option, Some, None};
+
+extern {
+  fn __STACK_BASE();
+}
+
+#[cfg(not(test))]
+#[no_mangle]
+#[no_stack_check]
+pub unsafe extern fn isr_default_fault() {
+  asm!("mrs r0, psp
+      mrs r1, msp
+      ldr r2, [r0, 0x18]
+      ldr r3, [r1, 0x18]
+      bkpt")
+}
+
+#[cfg(test)]
+pub extern fn isr_default_fault() { unimplemented!() }
+
+#[allow(non_upper_case_globals)]
+const ISRCount: uint = 16;
+
+#[link_section=".isr_vector"]
+#[allow(non_upper_case_globals)]
+#[no_mangle]
+pub static ISRVectors: [Option<unsafe extern fn()>, ..ISRCount] = [
+  Some(__STACK_BASE),
+  Some(::main),               // Reset entry point
+  None,                       // NMI
+  None,                       // Hard Fault
+  None,                       // CM3 Memory Management Fault
+  None,                       // CM3 Bus Fault
+  None,                       // CM3 Usage Fault
+  None,                       // Reserved
+  None,                       // Reserved
+  None,                       // Reserved
+  None,                       // Reserved
+  None,                       // SVCall
+  None,                       // Reserved for debug
+  None,                       // Reserved
+  None,                       // PendSV
+  None,                       // SysTick
+];
+
+#[allow(non_upper_case_globals)]
+const VISRCount: uint = 95;
+
+#[link_section=".isr_vector_nvic"]
+#[allow(non_upper_case_globals)]
+#[no_mangle]
+pub static NVICVectors: [Option<unsafe extern fn()>, ..VISRCount] = [
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+  None,
+];

--- a/src/ioreg/Cargo.toml
+++ b/src/ioreg/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ioreg"
+version = "0.0.1"
+authors = ["bgamari@gmail.com"]
+
+[lib]
+name = "ioreg"
+path = "ioreg.rs"
+plugin = true
+
+[dev-dependencies.hamcrest]
+git = "https://github.com/carllerche/hamcrest-rust.git"

--- a/support/target-specs/thumbv7em-none-eabi.json
+++ b/support/target-specs/thumbv7em-none-eabi.json
@@ -6,5 +6,12 @@
     "arch": "arm",
     "os": "none",
     "morestack": false,
-    "executables": true
+    "executables": true,
+    "linker": "arm-none-eabi-gcc",
+    "no-compiler-rt": true,
+    "relocation_model": "static",
+    "pre-link-args": [
+      "-Wl,-Map,app.map",
+      "-Wl,-T,layout.ld"
+    ]
 }


### PR DESCRIPTION
Not finished, but I'm just working through it now. You can build the zinc rlib with

    cargo build --target thumbv7em-linux-eabi

I've also removed the macro_ioreg crate and merged into the single ioreg crate as part of this. Next steps are doing the flexible target specification now that is has landed and also making changes to include all the static libs in the one go.