### PR TITLE
Modify travis build to use GitHub tarballs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ install:
     - tar xf rust.tgz
     - (cd ./rust-nightly-x86_64-unknown-linux-gnu/; sudo ./install.sh)
     - export LD_LIBRARY_PATH=/usr/local/lib
-    - (mkdir -p ./thirdparty; cd ./thirdparty; git clone --depth 50 https://github.com/rust-lang/rust)
-    - "(cd ./thirdparty/rust; git checkout `rustc --version|awk '{sub(/\\(/, \"\", $3); print $3}'`)"
+    - (mkdir -p ./thirdparty/rust)
+    - "(cd ./thirdparty/rust; wget -O rust.tar.gz https://github.com/rust-lang/rust/tarball/`rustc --version|awk '{sub(/\\(/, \"\", $3); print $3}'`; tar -zx --strip-components=1 -f rust.tar.gz)"
 before_script:
     - rustc --version
 script:


### PR DESCRIPTION
Instead of cloning and checkout, just grab the appropriate tarball
from GitHub.
