### PR TITLE
Use a different rlibc repo

### DIFF
--- a/support/rake.rb
+++ b/support/rake.rb
@@ -156,7 +156,7 @@ def provide_stdlibs
   end.invoke
 
   Rake::FileTask.define_task 'thirdparty/librlibc'.in_root do |t|
-    sh "git clone https://github.com/rust-lang/rlibc #{t.name}"
+    sh "git clone https://github.com/bharrisau/rust-librlibc #{t.name}"
   end.invoke
 
   Rake::FileTask.define_task 'thirdparty/libcore/lib.rs'.in_root do |t|


### PR DESCRIPTION
The rust-lang repo doesn't include crate_name or crate_type.

I was a bit eager assuming this was a nightly problem.
