### PR TITLE
Modifications to correct Travis build

### DIFF
--- a/src/zinc/lib.rs
+++ b/src/zinc/lib.rs
@@ -45,7 +45,7 @@ STM32F403/407).
 */
 
 #[phase(plugin,link)] extern crate core;
-extern crate rlibc;
+#[cfg(not(test))] extern crate rlibc;
 
 #[cfg(test)] #[phase(plugin,link)] extern crate std;
 #[cfg(test)] extern crate native;

--- a/support/rake.rb
+++ b/support/rake.rb
@@ -138,7 +138,6 @@ end
 
 def rust_tests(n, h)
   h[:test] = true
-  h[:flags] = '-C relocation-model=static'
   h[:optimize] = '0'
   compile_rust n, h
   run_task = Rake::Task.define_task("run_#{n}".to_sym => h[:produce]) do |t|


### PR DESCRIPTION
Why was relocation-model set to static for the native tests?
