### PR TITLE
Discard .ARM.extab

### DIFF
--- a/src/zinc/hal/k20/layout.ld
+++ b/src/zinc/hal/k20/layout.ld
@@ -80,7 +80,8 @@ SECTIONS
         *(.vfp11_veneer)  /* VFP11 bugfixes s.a. http://sourceware.org/ml/binutils/2006-12/msg00196.html */
         *(.iplt .igot.plt)  /* STT_GNU_IFUNC symbols */
         *(.rel.*)  /* dynamic relocations */
-        *(.ARM.exidx*) /* exception handling */
+        *(.ARM.exidx*) /* index entries for section unwinding */
+        *(.ARM.extab*) /* exception unwinding information */
     }
 }
 

--- a/src/zinc/hal/layout_common.ld
+++ b/src/zinc/hal/layout_common.ld
@@ -51,6 +51,7 @@ SECTIONS
         *(.vfp11_veneer)  /* VFP11 bugfixes s.a. http://sourceware.org/ml/binutils/2006-12/msg00196.html */
         *(.iplt .igot.plt)  /* STT_GNU_IFUNC symbols */
         *(.rel.*)  /* dynamic relocations */
-        *(.ARM.exidx*) /* exception handling */
+        *(.ARM.exidx*) /* index entries for section unwinding */
+        *(.ARM.extab*) /* exception unwinding information */
     }
 }


### PR DESCRIPTION
Based on aaelf this is the second section that is used to handle unwinding.
