### PR TITLE
Changed portG to portD to light leds on the stm32f407 Discovery Board

### DIFF
--- a/apps/app_blink_stm32f4.rs
+++ b/apps/app_blink_stm32f4.rs
@@ -15,12 +15,12 @@ pub unsafe fn main() {
   zinc::hal::mem_init::init_data();
 
   let led1 = pin::PinConf{
-    port: pin::PortG,
+    port: pin::PortD,
     pin: 13u8,
     function: pin::GPIOOut
   };
   let led2 = pin::PinConf{
-    port: pin::PortG,
+    port: pin::PortD,
     pin: 14u8,
     function: pin::GPIOOut
   };


### PR DESCRIPTION
Is the STM platform referenced from the project main page the STM32F407 Discovery Board? If so, the LEDs on the STM32f4 Discovery Board are on PortD instead of PortG.
