### PR TITLE
Updated target specs and cleaned up compile flags

### DIFF
--- a/support/build/context.rb
+++ b/support/build/context.rb
@@ -106,8 +106,6 @@ class Context
 
     @env[:rustcflags_cross] = [
       "--target #{@platform.arch.target}",
-      "-Ctarget-cpu=#{@platform.arch.cpu}",
-      '-C relocation_model=static',
     ]
 
     @env[:rustcflags] = [

--- a/support/rake.rb
+++ b/support/rake.rb
@@ -79,7 +79,6 @@ def compile_rust(n, h)
     flags += ' ' + :rustcflags_cross.in_env.join(' ') unless build_for_host
     flags += ' --test' if is_test
     flags += ' -g'
-    flags += ' -C no-stack-check'
     flags += ' ' + more_flags
 
     if optimize

--- a/support/target-specs/thumbv7em-none-eabi.json
+++ b/support/target-specs/thumbv7em-none-eabi.json
@@ -1,10 +1,13 @@
 {
-    "data-layout": "e-m:e-p:32:32-i1:8:32-i8:8:32-i16:16:32-i64:64-v128:64:128-a:0:32-n32-S64",
-    "llvm-target": "thumbv7em-none-eabi",
-    "target-endian": "little",
-    "target-word-size": "32",
     "arch": "arm",
-    "os": "none",
+    "cpu": "cortex-m4",
+    "data-layout": "e-m:e-p:32:32-i1:8:32-i8:8:32-i16:16:32-i64:64-v128:64:128-a:0:32-n32-S64",
+    "disable-redzone": true,
+    "executables": true,
+    "llvm-target": "thumbv7em-none-eabi",
     "morestack": false,
-    "executables": true
+    "os": "none",
+    "relocation-model": "static",
+    "target-endian": "little",
+    "target-word-size": "32"
 }

--- a/support/target-specs/thumbv7m-none-eabi.json
+++ b/support/target-specs/thumbv7m-none-eabi.json
@@ -1,10 +1,13 @@
 {
-    "data-layout": "e-m:e-p:32:32-i1:8:32-i8:8:32-i16:16:32-i64:64-v128:64:128-a:0:32-n32-S64",
-    "llvm-target": "thumbv7m-none-eabi",
-    "target-endian": "little",
-    "target-word-size": "32",
     "arch": "arm",
-    "os": "none",
+    "cpu": "cortex-m3",
+    "data-layout": "e-m:e-p:32:32-i1:8:32-i8:8:32-i16:16:32-i64:64-v128:64:128-a:0:32-n32-S64",
+    "disable-redzone": true,
+    "executables": true,
+    "llvm-target": "thumbv7m-none-eabi",
     "morestack": false,
-    "executables": true
+    "os": "none",
+    "relocation-model": "static",
+    "target-endian": "little",
+    "target-word-size": "32"
 }


### PR DESCRIPTION
Extracted everything that fits into target specs.

Apparently `mcu_*` config option is still relevant.
