### PR TITLE
Supported MCU list update

### DIFF
--- a/src/zinc/lib.rs
+++ b/src/zinc/lib.rs
@@ -39,6 +39,9 @@ Two MCUs are supported at the moment, specifically
 
  * NXP LPC1768
  * ST STM32F407
+ * ST STM32L152RCT6
+ * Freescale MK20DX32
+ * TI TM4C123GXL
 
 The code is generic enough to support other MCUs in the same family (LPC17xx and
 STM32F403/407).


### PR DESCRIPTION
I updated the list of MCU supported in zinc in docs comments.
Please can we update zinc.rs docs pages? They contain outdated files.
