### PR TITLE
Fix warnings

### DIFF
--- a/apps/app_empty.rs
+++ b/apps/app_empty.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, asm, no_std)]
+#![feature(core, plugin, asm, no_std)]
 #![crate_type="staticlib"]
 #![no_std]
 #![plugin(macro_platformtree)]

--- a/src/ioreg/ioreg.rs
+++ b/src/ioreg/ioreg.rs
@@ -330,7 +330,6 @@ N => NAME
 #![feature(quote, plugin_registrar, rustc_private, collections, core)]
 #![crate_name="ioreg"]
 #![crate_type="dylib"]
-#![allow(unstable)]
 
 extern crate rustc;
 extern crate syntax;

--- a/src/macro/platformtree.rs
+++ b/src/macro/platformtree.rs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(core, rustc_private, collections, plugin_registrar, quote)]
 #![crate_name="macro_platformtree"]
 #![crate_type="dylib"]
-#![warn(missing_docs)]
 
-#![feature(plugin_registrar, quote)]
 
 extern crate platformtree;
 extern crate rustc;

--- a/src/platformtree/builder/meta_args.rs
+++ b/src/platformtree/builder/meta_args.rs
@@ -19,7 +19,7 @@ use syntax::ext::base::ExtCtxt;
 use syntax::ext::build::AstBuilder;
 use syntax::parse::token::{InternedString, intern_and_get_ident};
 use syntax::ptr::P;
-use std::hash::{hash, Hash, SipHasher};
+use std::hash::{hash, SipHasher};
 
 static TAG: &'static str = "__zinc_task_ty_params";
 

--- a/src/platformtree/builder/mod.rs
+++ b/src/platformtree/builder/mod.rs
@@ -99,7 +99,7 @@ impl Builder {
       let mut sub_deps = sub.depends_on.borrow_mut();
       let deps = sub_deps.deref_mut();
       let mut index = None;
-      let mut i = 0u;
+      let mut i = 0usize;
       // FIXME: iter().position()
       for dep in deps.iter() {
         let strong_dep = dep.upgrade().unwrap();

--- a/src/platformtree/platformtree.rs
+++ b/src/platformtree/platformtree.rs
@@ -15,7 +15,7 @@
 
 //! Platform tree operations crate
 
-#![feature(quote, globs, rustc_private, collections, core, alloc)]
+#![feature(quote, rustc_private, collections, core, alloc, old_fmt, unicode, hash)]
 
 #![crate_name="platformtree"]
 #![crate_type="rlib"]

--- a/src/zinc/drivers/dht22.rs
+++ b/src/zinc/drivers/dht22.rs
@@ -66,7 +66,7 @@ impl<'a, T: Timer, P: Gpio> DHT22<'a, T, P> {
       return None
     }
 
-    for _ in range(0u, 40) {
+    for _ in range(0usize, 40) {
       if !self.wait_while(Low, 80) {
         return None
       }

--- a/src/zinc/drivers/lcd/c12332.rs
+++ b/src/zinc/drivers/lcd/c12332.rs
@@ -229,7 +229,7 @@ impl<'a, S: Spi, T: Timer, P: Gpio> LCD for C12332<'a, S, T, P> {
   }
 
   fn clear(&self) {
-    for i in range(0u, 512) {
+    for i in range(0usize, 512) {
       self.videobuf[i].set(0);
     }
   }

--- a/src/zinc/drivers/lcd/ili9341.rs
+++ b/src/zinc/drivers/lcd/ili9341.rs
@@ -278,7 +278,7 @@ impl<'a, S: Spi, T: Timer, P: Gpio> ILI9341<'a, S, T, P> {
 
     self.dc.set_high();
     self.cs.set_low();
-    for _ in range(0u, 38400) {
+    for _ in range(0usize, 38400) {
       self.spi.transfer(0);
       self.spi.transfer(0);
       self.spi.transfer(0);

--- a/src/zinc/hal/isr.rs
+++ b/src/zinc/hal/isr.rs
@@ -16,7 +16,7 @@
 //! This file is not part of zinc crate, it is linked separately, alongside the
 //! ISRs for the platform.
 
-#![feature(asm, globs, lang_items, no_std)]
+#![feature(core, asm, lang_items, no_std)]
 #![crate_name="isr"]
 #![crate_type="staticlib"]
 #![no_std]

--- a/src/zinc/hal/tiva_c/sysctl.rs
+++ b/src/zinc/hal/tiva_c/sysctl.rs
@@ -293,7 +293,7 @@ pub mod periph {
       // maybe because we also have to take the bus write time into account or
       // the CPU is more clever than I think. Anyway, looping 5 times seems to
       // work
-      for _ in range(0u, 10) {
+      for _ in range(0usize, 10) {
         unsafe {
           asm!("nop" :::: "volatile");
         }

--- a/src/zinc/hal/tiva_c/sysctl.rs
+++ b/src/zinc/hal/tiva_c/sysctl.rs
@@ -276,7 +276,7 @@ pub mod periph {
       let p = base as *const super::reg::SysCtl_rmcgc;
 
       unsafe {
-        &*p.offset(self.class as int)
+        &*p.offset(self.class as isize)
       }
     }
 

--- a/src/zinc/util/shared.rs
+++ b/src/zinc/util/shared.rs
@@ -18,7 +18,6 @@
 use core::cell::UnsafeCell;
 use core::ops::{Deref, DerefMut};
 use core::marker::{Sync, Send};
-use core::marker;
 
 use hal::cortex_m3::irq::NoInterrupts;
 

--- a/src/zinc/util/strconv.rs
+++ b/src/zinc/util/strconv.rs
@@ -21,7 +21,7 @@ use core::mem::uninitialized;
 pub fn itoa(val: u32, buf : &mut [u8], base: u32) {
   let mut rbuf : [u8; 32] = unsafe { uninitialized() };
   let mut myval : u32 = val;
-  let mut idx: int = 0;
+  let mut idx: isize = 0;
 
   if myval == 0 {
     buf[0] = '0' as u8;

--- a/thirdparty/librlibc/src/lib.rs
+++ b/thirdparty/librlibc/src/lib.rs
@@ -40,10 +40,10 @@ use core::ptr::PtrExt;
 
 #[no_mangle]
 pub unsafe extern fn memcpy(dest: *mut u8, src: *const u8,
-                            n: uint) -> *mut u8 {
+                            n: usize) -> *mut u8 {
     let mut i = 0;
     while i < n {
-        *dest.offset(i as int) = *src.offset(i as int);
+        *dest.offset(i as isize) = *src.offset(i as isize);
         i += 1;
     }
     return dest;
@@ -51,17 +51,17 @@ pub unsafe extern fn memcpy(dest: *mut u8, src: *const u8,
 
 #[no_mangle]
 pub unsafe extern fn memmove(dest: *mut u8, src: *const u8,
-                             n: uint) -> *mut u8 {
+                             n: usize) -> *mut u8 {
     if src < dest as *const u8 { // copy from end
         let mut i = n;
         while i != 0 {
             i -= 1;
-            *dest.offset(i as int) = *src.offset(i as int);
+            *dest.offset(i as isize) = *src.offset(i as isize);
         }
     } else { // copy from beginning
         let mut i = 0;
         while i < n {
-            *dest.offset(i as int) = *src.offset(i as int);
+            *dest.offset(i as isize) = *src.offset(i as isize);
             i += 1;
         }
     }
@@ -69,21 +69,21 @@ pub unsafe extern fn memmove(dest: *mut u8, src: *const u8,
 }
 
 #[no_mangle]
-pub unsafe extern fn memset(s: *mut u8, c: i32, n: uint) -> *mut u8 {
+pub unsafe extern fn memset(s: *mut u8, c: i32, n: usize) -> *mut u8 {
     let mut i = 0;
     while i < n {
-        *s.offset(i as int) = c as u8;
+        *s.offset(i as isize) = c as u8;
         i += 1;
     }
     return s;
 }
 
 #[no_mangle]
-pub unsafe extern fn memcmp(s1: *const u8, s2: *const u8, n: uint) -> i32 {
+pub unsafe extern fn memcmp(s1: *const u8, s2: *const u8, n: usize) -> i32 {
     let mut i = 0;
     while i < n {
-        let a = *s1.offset(i as int);
-        let b = *s2.offset(i as int);
+        let a = *s1.offset(i as isize);
+        let b = *s2.offset(i as isize);
         if a != b {
             return a as i32 - b as i32
         }

--- a/thirdparty/librlibc/src/lib.rs
+++ b/thirdparty/librlibc/src/lib.rs
@@ -20,10 +20,10 @@
 //! necessary. It is an error to include this library when also linking with
 //! the system libc library.
 
+#![feature(no_std, core)]
 #![crate_name = "rlibc"]
 #![crate_type = "rlib"]
 
-#![feature(no_std)]
 #![no_std]
 
 // This library defines the builtin functions, so it would be a shame for


### PR DESCRIPTION
This should fix almost all warnings with ```rustc 1.0.0-nightly (522d09dfe 2015-02-19) (built 2015-02-21)```
Basically some int/uint -> usize/isize replacement and some feature attributes