### PR TITLE
Provide straightforward way to consume zinc without platformtree (remove #[start] boilerplate)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ after_script:
     - (cd ./ioreg; cargo build --verbose; cargo test --verbose)
     - (cd ./platformtree; cargo build --verbose; cargo test --verbose)
     - (cd ./macro_platformtree; cargo build --verbose; cargo test --verbose)
+    - (cd ./macro_zinc; cargo test --verbose)
 env:
   matrix:
     - PLATFORM=lpc17xx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ path = "./platformtree"
 [dev-dependencies.macro_platformtree]
 path = "./macro_platformtree"
 
+[dev-dependencies.macro_zinc]
+path = "./macro_zinc"
+
 [[example]]
 name = "nothing"
 path = "examples/app_nothing.rs"

--- a/examples/app_blink.rs
+++ b/examples/app_blink.rs
@@ -1,5 +1,6 @@
-#![feature(no_std, core, start)]
+#![feature(plugin, no_std, core, start)]
 #![no_std]
+#![plugin(macro_zinc)]
 
 extern crate core;
 extern crate zinc;
@@ -10,12 +11,7 @@ use zinc::hal::pin::GpioDirection;
 use zinc::hal::pin::Gpio;
 use core::option::Option::Some;
 
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-  main();
-  0
-}
-
+#[zinc_main]
 pub fn main() {
   zinc::hal::mem_init::init_stack();
   zinc::hal::mem_init::init_data();

--- a/examples/app_blink_k20.rs
+++ b/examples/app_blink_k20.rs
@@ -1,5 +1,6 @@
-#![feature(no_std, core, start)]
+#![feature(plugin, no_std, core, start)]
 #![no_std]
+#![plugin(macro_zinc)]
 
 extern crate core;
 extern crate zinc;
@@ -24,6 +25,7 @@ pub fn wait(ticks: u32) {
   }
 }
 
+#[zinc_main]
 pub fn main() {
   zinc::hal::mem_init::init_stack();
   zinc::hal::mem_init::init_data();
@@ -40,10 +42,4 @@ pub fn main() {
     led1.set_low();
     wait(10);
   }
-}
-
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-  main();
-  0
 }

--- a/examples/app_blink_stm32f4.rs
+++ b/examples/app_blink_stm32f4.rs
@@ -1,5 +1,6 @@
-#![feature(no_std, core, start)]
+#![feature(plugin, no_std, core, start)]
 #![no_std]
+#![plugin(macro_zinc)]
 
 extern crate core;
 extern crate zinc;
@@ -7,12 +8,7 @@ extern crate zinc;
 use zinc::hal::timer::Timer;
 use zinc::hal::stm32f4::{pin, timer};
 
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-  main();
-  0
-}
-
+#[zinc_main]
 pub fn main() {
   zinc::hal::mem_init::init_stack();
   zinc::hal::mem_init::init_data();

--- a/examples/app_blink_stm32l1.rs
+++ b/examples/app_blink_stm32l1.rs
@@ -1,15 +1,11 @@
-#![feature(no_std, core, start)]
+#![feature(plugin, no_std, core, start)]
 #![no_std]
-
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-  main();
-  0
-}
+#![plugin(macro_zinc)]
 
 extern crate core;
 extern crate zinc;
 
+#[zinc_main]
 fn main() {
   use core::option::Option;
   use zinc::hal::pin::Gpio;

--- a/examples/app_nothing.rs
+++ b/examples/app_nothing.rs
@@ -1,13 +1,9 @@
-#![feature(no_std, core, start)]
+#![feature(plugin, no_std, core, start)]
 #![no_std]
+#![plugin(macro_zinc)]
 
 extern crate zinc;
 
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-  main();
-  0
-}
-
+#[zinc_main]
 pub fn main() {
 }

--- a/examples/app_usart_stm32l1.rs
+++ b/examples/app_usart_stm32l1.rs
@@ -1,15 +1,11 @@
-#![feature(no_std, core, start)]
+#![feature(plugin, no_std, core, start)]
 #![no_std]
+#![plugin(macro_zinc)]
 
 extern crate core;
 extern crate zinc;
 
-#[start]
-fn start(_: isize, _: *const *const u8) -> isize {
-  main();
-  0
-}
-
+#[zinc_main]
 pub fn main() {
   use zinc::drivers::chario::CharIO;
   use zinc::hal;

--- a/macro_zinc/Cargo.toml
+++ b/macro_zinc/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "macro_zinc"
+version = "0.1.0"
+authors = ["Matt Coffin <mcoffin13@gmail.com>"]
+
+[lib]
+name = "macro_zinc"
+plugin = true

--- a/macro_zinc/src/lib.rs
+++ b/macro_zinc/src/lib.rs
@@ -1,0 +1,61 @@
+// Zinc, the bare metal stack for rust.
+// Copyright 2014 Matt "mcoffin" Coffin <mcoffin13@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(rustc_private, plugin_registrar, quote)]
+
+extern crate rustc;
+extern crate syntax;
+
+use rustc::plugin::Registry;
+use syntax::ast::MetaItem;
+use syntax::codemap::{Span, DUMMY_SP};
+use syntax::ext::base::{Annotatable, ExtCtxt, MultiDecorator};
+use syntax::ext::build::AstBuilder;
+
+macro_rules! and_return {
+  ($a:stmt) => (
+    {
+      $a;
+      return;
+    }
+    )
+}
+
+#[plugin_registrar]
+pub fn plugin_registrar(reg: &mut Registry) {
+  reg.register_syntax_extension(syntax::parse::token::intern("zinc_main"),
+  MultiDecorator(Box::new(decorator_zinc_main)));
+}
+
+pub fn decorator_zinc_main(cx: &mut ExtCtxt,
+                           sp: Span,
+                           _: &MetaItem,
+                           item: &Annotatable,
+                           push: &mut FnMut(Annotatable)) {
+  let main = match item {
+    &Annotatable::Item(ref main_item) => (*main_item).ident,
+    _ => and_return!(cx.span_err(sp, "zinc_main must be an item")),
+  };
+
+  let call_main = cx.expr_call_ident(DUMMY_SP, main, Vec::new());
+  let start = quote_item!(cx,
+    #[start]
+    fn start(_: isize, _: *const *const u8) -> isize {
+      $call_main;
+      0
+    }
+  ).unwrap();
+  push(Annotatable::Item(start));
+}


### PR DESCRIPTION
This removes the `#[start]` boilerplate code by adding a simple `#[zinc_main]` annotation that allows the user to specify which of their methods should be called at startup.

This is needed because there should be a straightforward way to consume `zinc` without `platformtree`. Right now, platformtree will provide `#[start]` code, but non-platformtree consumers are currently required to provide a boilerplate implementation.

Only drawback I really is is having to maintain another syntax extension... but zinc is already so heavily dependent upon them that I don't see that as much of a downside at all, especially considering the simplicity of this one.