### PR TITLE
Minimize use of DUMMY_SP

### DIFF
--- a/ioreg/Cargo.toml
+++ b/ioreg/Cargo.toml
@@ -9,3 +9,6 @@ plugin = true
 
 [dev-dependencies.volatile_cell]
 path = "../volatile_cell"
+
+[dependencies]
+syntaxext_lint = "*"

--- a/ioreg/src/builder/accessors.rs
+++ b/ioreg/src/builder/accessors.rs
@@ -15,7 +15,6 @@
 
 use syntax::ast;
 use syntax::ptr::P;
-use syntax::codemap::DUMMY_SP;
 use syntax::ext::base::ExtCtxt;
 use syntax::ext::build::AstBuilder;
 use syntax::ext::quote::rt::ToTokens;
@@ -33,7 +32,7 @@ pub struct BuildAccessors<'a> {
 
 impl<'a> node::RegVisitor for BuildAccessors<'a> {
   fn visit_prim_reg(&mut self, path: &Vec<String>, reg: &node::Reg,
-                    _width: &node::RegWidth, fields: &Vec<node::Field>) {
+                    fields: &Vec<node::Field>) {
     if fields.iter().any(|f| f.access != node::Access::WriteOnly) {
       let item = build_get_fn(self.cx, path, reg);
       self.builder.push_item(item);
@@ -60,7 +59,7 @@ fn build_field_accessors(cx: &ExtCtxt, path: &Vec<String>,
                          -> Option<P<ast::Item>>
 {
   let reg_ty: P<ast::Ty> =
-    cx.ty_ident(DUMMY_SP, utils::path_ident(cx, path));
+    cx.ty_ident(reg.name.span, utils::path_ident(cx, path));
 
   let items = match field.access {
     node::Access::ReadWrite => vec!(build_field_set_fn(cx, path, reg, field),
@@ -103,7 +102,7 @@ fn build_get_fn(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg)
                 -> P<ast::Item>
 {
   let reg_ty: P<ast::Ty> =
-    cx.ty_ident(DUMMY_SP, utils::path_ident(cx, path));
+    cx.ty_ident(reg.name.span, utils::path_ident(cx, path));
   let getter_ty = utils::getter_name(cx, path);
 
   let docstring = format!("Fetch the value of the `{}` register",
@@ -126,7 +125,7 @@ fn build_field_set_fn(cx: &ExtCtxt, path: &Vec<String>,
                       reg: &node::Reg, field: &node::Field)
                       -> P<ast::ImplItem>
 {
-  let reg_ty = cx.ty_ident(DUMMY_SP, utils::path_ident(cx, path));
+  let reg_ty = cx.ty_ident(reg.name.span, utils::path_ident(cx, path));
   let fn_name =
     cx.ident_of((String::from_str("set_")+field.name.node.as_str()).as_str());
   let field_ty: P<ast::Ty> =
@@ -161,7 +160,7 @@ fn build_field_get_fn(cx: &ExtCtxt, path: &Vec<String>,
                       reg: &node::Reg, field: &node::Field)
                       -> P<ast::ImplItem>
 {
-  let reg_ty = cx.ty_ident(DUMMY_SP, utils::path_ident(cx, path));
+  let reg_ty = cx.ty_ident(reg.name.span, utils::path_ident(cx, path));
   utils::unwrap_impl_item({
       let fn_name = cx.ident_of(field.name.node.as_str());
       let field_ty: P<ast::Ty> =
@@ -190,10 +189,10 @@ fn build_field_get_fn(cx: &ExtCtxt, path: &Vec<String>,
 }
 
 fn build_field_clear_fn(cx: &ExtCtxt, path: &Vec<String>,
-                        _reg: &node::Reg, field: &node::Field)
+                        reg: &node::Reg, field: &node::Field)
                         -> P<ast::ImplItem>
 {
-  let reg_ty = cx.ty_ident(DUMMY_SP, utils::path_ident(cx, path));
+  let reg_ty = cx.ty_ident(reg.name.span, utils::path_ident(cx, path));
   let fn_name =
     cx.ident_of((String::from_str("clear_")+field.name.node.as_str()).as_str());
   let setter_ty = utils::setter_name(cx, path);

--- a/ioreg/src/lib.rs
+++ b/ioreg/src/lib.rs
@@ -329,6 +329,9 @@ N => NAME
 
 #![feature(quote, plugin_registrar, rustc_private, collections, core)]
 #![feature(convert)]
+#![feature(plugin)]
+
+#![plugin(syntaxext_lint)]
 
 extern crate rustc;
 extern crate syntax;

--- a/ioreg/src/node.rs
+++ b/ioreg/src/node.rs
@@ -95,7 +95,7 @@ impl RegWidth {
 #[derive(Clone)]
 pub enum RegType {
   /// A primitive bitfield
-  RegPrim(RegWidth, Vec<Field>),
+  RegPrim(Spanned<RegWidth>, Vec<Field>),
   /// A group
   RegUnion(Rc<Vec<Reg>>),
 }
@@ -104,7 +104,7 @@ impl RegType {
   /// Size of register type in bytes
   pub fn size(&self) -> u64 {
     match self {
-      &RegType::RegPrim(ref width, _)  => width.size() as u64,
+      &RegType::RegPrim(ref width, _)  => width.node.size() as u64,
       &RegType::RegUnion(ref regs) => regs_size(regs.deref()),
     }
   }
@@ -142,7 +142,7 @@ pub fn regs_size(regs: &Vec<Reg>) -> u64 {
 pub trait RegVisitor {
   /// Path includes name of `Reg` being visited
   fn visit_prim_reg<'a>(&'a mut self, _path: &Vec<String>, _reg: &'a Reg,
-                        _width: &RegWidth, _fields: &Vec<Field>) {}
+                        _fields: &Vec<Field>) {}
   fn visit_union_reg<'a>(&'a mut self, _path: &Vec<String>, _reg: &'a Reg,
                          _subregs: Rc<Vec<Reg>>) {}
 }
@@ -161,7 +161,7 @@ fn visit_reg_<T: RegVisitor>(reg: &Reg, visitor: &mut T, path: Vec<String>) {
         visit_reg_(r, visitor, new_path);
       }
     },
-    RegType::RegPrim(ref width, ref fields) =>
-      visitor.visit_prim_reg(&path, reg, width, fields)
+    RegType::RegPrim(_, ref fields) =>
+      visitor.visit_prim_reg(&path, reg, fields)
   }
 }


### PR DESCRIPTION
Makes more meaningful feedback from macro builders.

Fixes  (for ioreg, not for platformtree) #99