### PR TITLE
Ioreg improvements

### DIFF
--- a/ioreg/src/builder/accessors.rs
+++ b/ioreg/src/builder/accessors.rs
@@ -129,7 +129,7 @@ fn build_ignoring_state_setter_fn(cx: &ExtCtxt, path: &Vec<String>, reg: &node::
                 -> P<ast::Item>
 {
   let reg_ty: P<ast::Ty> =
-    cx.ty_ident(DUMMY_SP, utils::path_ident(cx, path));
+    cx.ty_ident(reg.name.span, utils::path_ident(cx, path));
   let setter_ty = utils::setter_name(cx, path);
 
   let docstring = format!("Create new updater that ignores current value of the `{}` register",

--- a/ioreg/src/builder/setter.rs
+++ b/ioreg/src/builder/setter.rs
@@ -109,10 +109,10 @@ fn build_new<'a>(cx: &'a ExtCtxt, path: &Vec<String>, reg: &node::Reg)
   ).unwrap())
 }
 
-fn build_new_ignoring_state<'a>(cx: &'a ExtCtxt, path: &Vec<String>)
-                 -> P<ast::ImplItem> {
+fn build_new_ignoring_state<'a>(cx: &'a ExtCtxt, path: &Vec<String>,
+    reg: &node::Reg) -> P<ast::ImplItem> {
   let reg_ty: P<ast::Ty> =
-    cx.ty_ident(DUMMY_SP, utils::path_ident(cx, path));
+    cx.ty_ident(reg.name.span, utils::path_ident(cx, path));
   let setter_ident = utils::setter_name(cx, path);
   utils::unwrap_impl_item(quote_item!(cx,
     impl<'a> $setter_ident<'a> {

--- a/ioreg/src/builder/union.rs
+++ b/ioreg/src/builder/union.rs
@@ -238,6 +238,10 @@ impl<'a> BuildUnionTypes<'a> {
           unsafe { ::core::intrinsics::transmute($item_address as usize) }
       }
     ).unwrap();
-    vec!(struct_item, clone_impl, copy_impl, item_getter)
+    if item_address == 0 {
+      vec!(struct_item, clone_impl, copy_impl)
+    } else {
+      vec!(struct_item, clone_impl, copy_impl, item_getter)
+    }
   }
 }

--- a/ioreg/src/builder/union.rs
+++ b/ioreg/src/builder/union.rs
@@ -228,7 +228,16 @@ impl<'a> BuildUnionTypes<'a> {
         }
       }
     ).unwrap();
+
     let copy_impl = quote_item!(self.cx, impl ::core::marker::Copy for $name {}).unwrap();
-    vec!(struct_item, clone_impl, copy_impl)
+
+    let item_address = reg.address;
+    let item_getter = quote_item!(self.cx,
+      #[allow(non_snake_case, dead_code)]
+      pub fn $name() -> &'static $name {
+          unsafe { ::core::intrinsics::transmute($item_address as usize) }
+      }
+    ).unwrap();
+    vec!(struct_item, clone_impl, copy_impl, item_getter)
   }
 }

--- a/ioreg/src/lib.rs
+++ b/ioreg/src/lib.rs
@@ -327,10 +327,9 @@ N => NAME
 
 */
 
-#![feature(quote, plugin_registrar, rustc_private, collections, core)]
-#![feature(convert)]
-#![feature(plugin)]
+#![feature(quote, plugin_registrar, rustc_private, collections, core, convert)]
 
+#![feature(plugin)]
 #![plugin(syntaxext_lint)]
 
 extern crate rustc;

--- a/ioreg/src/node.rs
+++ b/ioreg/src/node.rs
@@ -19,7 +19,7 @@ use syntax::codemap::{Spanned, Span};
 use syntax::ast;
 
 /// A variant of an enum field type
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Variant {
   pub name: Spanned<String>,
   pub value: Spanned<u64>,
@@ -27,7 +27,7 @@ pub struct Variant {
 }
 
 /// A bit field type
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum FieldType {
   /// A unsigned integer
   UIntField,
@@ -40,7 +40,7 @@ pub enum FieldType {
   },
 }
 
-#[derive(Copy, PartialEq, Eq, Clone)]
+#[derive(Copy, PartialEq, Eq, Clone, Debug)]
 pub enum Access {
   ReadWrite,
   ReadOnly,
@@ -49,7 +49,7 @@ pub enum Access {
   SetToClear,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Field {
   pub name: Spanned<String>,
   /// The index of the first (lowest order) bit of the field
@@ -71,7 +71,7 @@ impl Field {
   }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum RegWidth {
   /// A 32-bit wide register
   Reg32,
@@ -92,7 +92,7 @@ impl RegWidth {
   }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum RegType {
   /// A primitive bitfield
   RegPrim(Spanned<RegWidth>, Vec<Field>),
@@ -111,13 +111,14 @@ impl RegType {
 }
 
 /// A single register, either a union or primitive
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Reg {
   pub offset: u64,
   pub name: Spanned<String>,
   pub ty: RegType,
   pub count: Spanned<u32>,
   pub docstring: Option<Spanned<ast::Ident>>,
+  pub address: usize,
 }
 
 impl Reg {

--- a/ioreg/src/parser.rs
+++ b/ioreg/src/parser.rs
@@ -76,16 +76,17 @@ impl<'a> Parser<'a> {
       Some(name) => respan(self.last_span, name),
       None => return None,
     };
+    let mut address: usize = 0;
 
-    if !self.expect(&token::At) {
-      return None;
+    if self.token == token::At {
+      self.bump();
+
+      // TODO(farcaller): expect_usize should return usize, no?
+      address = match self.expect_usize() {
+        Some(address) => address as usize,
+        None => return None,
+      };
     }
-
-    // TODO(farcaller): expect_usize should return usize, no?
-    let address = match self.expect_usize() {
-      Some(address) => address as usize,
-      None => return None,
-    };
 
     if !self.expect(&token::Eq) {
       return None;

--- a/ioreg/tests/test.rs
+++ b/ioreg/tests/test.rs
@@ -39,7 +39,7 @@ mod test {
     }
   }
 
-  ioregs!(BASIC_TEST = {
+  ioregs!(BASIC_TEST @ 0 = {
     0x0 => reg32 reg1 {
       0      => field1,
       1..3   => field2,
@@ -125,7 +125,7 @@ mod test {
      );
      */
 
-  ioregs!(GROUP_TEST = {
+  ioregs!(GROUP_TEST @ 0 = {
     0x0 => group regs[5] {
       0x0 => reg32 reg1 {
         0..31 => field1
@@ -172,7 +172,7 @@ mod test {
      );
      */
 
-  ioregs!(FIELD_ARRAY_TEST = {
+  ioregs!(FIELD_ARRAY_TEST @ 0 = {
     0x0 => reg32 reg1 {
       0..31 => field[16]
     }
@@ -208,7 +208,7 @@ mod test {
      );
      */
 
-  ioregs!(GAP_TEST = {
+  ioregs!(GAP_TEST @ 0 = {
     0x0 => reg32 reg1 {
       0..31 => field,
     }
@@ -268,7 +268,7 @@ mod test {
      );
      */
 
-  ioregs!(MULTI_TEST = {
+  ioregs!(MULTI_TEST @ 0 = {
     0x100 => reg32 reg1[8] {
       0..31 => field[32],
     }


### PR DESCRIPTION
Added support for `ignoring_state` and placement getter, that allows code like this:

```rust
regs::SYSCON().sysoscctrl.ignoring_state()
    .set_bypass(regs::SYSCON_sysoscctrl_bypass::NOBYPASS)
    .set_freqrange(regs::SYSCON_sysoscctrl_freqrange::LOW);
```