### PR TITLE
Cargo feature refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
     - sudo apt-get install gcc-arm-none-eabi
 script:
     - ./configure --host=arm-none-eabi
-    - cargo build --target=$TARGET --verbose --features $PLATFORM
+    - cargo build --target=$TARGET --verbose --features mcu_$PLATFORM
     - ./support/build-examples.sh
 after_script:
     - cargo test --lib --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,11 @@ name = "zinc"
 crate-type = ["lib"]
 
 [features]
-lpc17xx = []
-stm32f4 = []
-stm32l1 = []
-k20 = []
-tiva_c = []
+mcu_lpc17xx = []
+mcu_stm32f4 = []
+mcu_stm32l1 = []
+mcu_k20 = []
+mcu_tiva_c = []
 
 [target.thumbv7m-none-eabi.dependencies.core]
 git = "https://github.com/hackndev/rust-libcore"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ mcu_stm32f4 = []
 mcu_stm32l1 = []
 mcu_k20 = []
 mcu_tiva_c = []
+multitasking = []
 
 [target.thumbv7m-none-eabi.dependencies.core]
 git = "https://github.com/hackndev/rust-libcore"

--- a/Makefile.in
+++ b/Makefile.in
@@ -39,7 +39,7 @@ listing: $(LST_FILE)
 # Target is PHONY so cargo can deal with dependencies
 $(EXAMPLE_FILE):
 	cd $(CARGO_ROOT)
-	cargo build --example $(EXAMPLE_NAME) $(PROFILE_OPTION) --target=$(TARGET) --verbose --features $(PLATFORM)
+	cargo build --example $(EXAMPLE_NAME) $(PROFILE_OPTION) --target=$(TARGET) --verbose --features mcu_$(PLATFORM)
 
 $(BIN_FILE): $(EXAMPLE_FILE)
 	$(OBJCOPY) -O binary $< $@

--- a/build.rs
+++ b/build.rs
@@ -5,10 +5,10 @@ use std::io;
 use std::path::Path;
 
 fn get_platform() -> Option<String> {
-  let features = env::vars().filter(|&(ref key, _)| key.starts_with("CARGO_FEATURE_"));
+  let features = env::vars().filter(|&(ref key, _)| key.starts_with("CARGO_FEATURE_MCU_"));
   match features.last() {
     Some((feature_var, _)) => Some(
-      feature_var.trim_left_matches("CARGO_FEATURE_")
+      feature_var.trim_left_matches("CARGO_FEATURE_MCU_")
         .to_string().to_ascii_lowercase()),
       None => None,
   }

--- a/src/hal/cortex_m3/mod.rs
+++ b/src/hal/cortex_m3/mod.rs
@@ -25,5 +25,5 @@ pub use super::cortex_common::scb;
 pub use super::cortex_common::nvic;
 pub use super::cortex_common::mpu;
 pub use super::cortex_common::irq;
-#[cfg(cfg_multitasking)] pub mod sched;
-#[cfg(cfg_multitasking)] pub mod lock;
+#[cfg(feature = "multitasking")] pub mod sched;
+#[cfg(feature = "multitasking")] pub mod lock;

--- a/src/hal/isr.rs
+++ b/src/hal/isr.rs
@@ -20,11 +20,11 @@
 
 #[path="cortex_m3/isr.rs"] pub mod isr_cortex_m3;
 
-#[cfg(feature = "lpc17xx")]
+#[cfg(feature = "mcu_lpc17xx")]
 #[path="lpc17xx/isr.rs"] pub mod isr_lpc17xx;
 
-#[cfg(feature = "k20")]
+#[cfg(feature = "mcu_k20")]
 #[path="k20/isr.rs"] pub mod isr_k20;
 
-#[cfg(feature = "tiva_c")]
+#[cfg(feature = "mcu_tiva_c")]
 #[path="tiva_c/isr.rs"] pub mod isr_tiva_c;

--- a/src/os/mod.rs
+++ b/src/os/mod.rs
@@ -22,7 +22,7 @@ incompatible direct hal usage in some cases.
 
 // pub mod debug;
 pub mod syscall;
-#[cfg(cfg_multitasking)] pub mod task;
+#[cfg(feature = "multitasking")] pub mod task;
 pub mod mutex;
 pub mod cond_var;
 pub mod debug;

--- a/src/util/app.rs
+++ b/src/util/app.rs
@@ -32,21 +32,21 @@ pub extern fn main() {
 
 #[no_stack_check]
 #[no_mangle]
-#[cfg(not(cfg_multitasking))]
+#[cfg(not(feature = "multitasking"))]
 pub extern fn __morestack() {
   unsafe { core::intrinsics::abort() };
 }
 
 #[no_stack_check]
 #[no_mangle]
-#[cfg(cfg_multitasking)]
+#[cfg(feature = "multitasking")]
 pub extern fn __morestack() {
   zinc::os::task::morestack();
 }
 
 #[no_stack_check]
 #[no_mangle]
-#[cfg(cfg_multitasking)]
+#[cfg(feature = "multitasking")]
 pub unsafe fn task_scheduler() {
   zinc::os::task::task_scheduler();
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -19,6 +19,6 @@ pub mod strconv;
 pub mod volatile_cell;
 pub mod support;
 pub mod shared;
-#[cfg(cfg_multitasking)] pub mod queue;
+#[cfg(feature = "multitasking")] pub mod queue;
 
 mod lang_items;


### PR DESCRIPTION
As exposed in #306, there's still a need for cargo features that aren't MCU features, and `build.rs` needs a way to tell them apart.

* Prefixed all the MCU features with `mcu_`
* Converted the old `cfg_multitasking` config flag to a cargo feature (`multitasking`)