### PR TITLE
6/23 Nightly fallout

### DIFF
--- a/examples/app_blink.rs
+++ b/examples/app_blink.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start)]
+#![feature(plugin, no_std, core, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/examples/app_blink_k20.rs
+++ b/examples/app_blink_k20.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start)]
+#![feature(plugin, no_std, core, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/examples/app_blink_k20_isr.rs
+++ b/examples/app_blink_k20_isr.rs
@@ -1,4 +1,4 @@
-#![feature(no_std, core, start)]
+#![feature(no_std, core, start, core_intrinsics)]
 #![no_std]
 
 extern crate core;

--- a/examples/app_blink_pt.rs
+++ b/examples/app_blink_pt.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start)]
+#![feature(plugin, no_std, core, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_platformtree)]
 

--- a/examples/app_blink_stm32f4.rs
+++ b/examples/app_blink_stm32f4.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start)]
+#![feature(plugin, no_std, core, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/examples/app_blink_stm32l1.rs
+++ b/examples/app_blink_stm32l1.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start)]
+#![feature(plugin, no_std, core, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/examples/app_blink_tiva_c.rs
+++ b/examples/app_blink_tiva_c.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start)]
+#![feature(plugin, no_std, core, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_platformtree)]
 

--- a/examples/app_bluenrg_stm32l1.rs
+++ b/examples/app_bluenrg_stm32l1.rs
@@ -1,4 +1,4 @@
-#![feature(no_std, core, start)]
+#![feature(no_std, core, start, core_intrinsics)]
 #![no_std]
 
 //! Sample application for BlueNRG communication over SPI in X-NUCLEO-IDB04A1

--- a/examples/app_dht22.rs
+++ b/examples/app_dht22.rs
@@ -1,4 +1,4 @@
-#![feature(start, plugin, no_std, core)]
+#![feature(start, plugin, no_std, core, core_intrinsics)]
 #![crate_type="staticlib"]
 #![no_std]
 #![plugin(macro_platformtree)]

--- a/examples/app_empty.rs
+++ b/examples/app_empty.rs
@@ -1,4 +1,4 @@
-#![feature(core, plugin, asm, no_std, start)]
+#![feature(core, plugin, asm, no_std, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/examples/app_lcd_tiva_c.rs
+++ b/examples/app_lcd_tiva_c.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start)]
+#![feature(plugin, no_std, core, start, core_intrinsics)]
 #![crate_type="staticlib"]
 #![no_std]
 #![plugin(macro_platformtree)]

--- a/examples/app_nothing.rs
+++ b/examples/app_nothing.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start)]
+#![feature(plugin, no_std, core, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/examples/app_uart.rs
+++ b/examples/app_uart.rs
@@ -1,4 +1,4 @@
-#![feature(start, plugin, no_std, core)]
+#![feature(start, plugin, no_std, core, core_intrinsics)]
 #![crate_type="staticlib"]
 #![no_std]
 #![plugin(macro_platformtree)]

--- a/examples/app_uart_tiva_c.rs
+++ b/examples/app_uart_tiva_c.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start)]
+#![feature(plugin, no_std, core, start, core_intrinsics)]
 #![crate_type="staticlib"]
 #![no_std]
 #![plugin(macro_platformtree)]

--- a/examples/app_usart_stm32l1.rs
+++ b/examples/app_usart_stm32l1.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start)]
+#![feature(plugin, no_std, core, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/ioreg/src/builder/accessors.rs
+++ b/ioreg/src/builder/accessors.rs
@@ -127,7 +127,7 @@ fn build_field_set_fn(cx: &ExtCtxt, path: &Vec<String>,
 {
   let reg_ty = cx.ty_ident(reg.name.span, utils::path_ident(cx, path));
   let fn_name =
-    cx.ident_of((String::from_str("set_")+field.name.node.as_str()).as_str());
+    cx.ident_of((String::from("set_")+field.name.node.as_str()).as_str());
   let field_ty: P<ast::Ty> =
     cx.ty_path(utils::field_type_path(cx, path, reg, field));
   let setter_ty = utils::setter_name(cx, path);
@@ -194,7 +194,7 @@ fn build_field_clear_fn(cx: &ExtCtxt, path: &Vec<String>,
 {
   let reg_ty = cx.ty_ident(reg.name.span, utils::path_ident(cx, path));
   let fn_name =
-    cx.ident_of((String::from_str("clear_")+field.name.node.as_str()).as_str());
+    cx.ident_of((String::from("clear_")+field.name.node.as_str()).as_str());
   let setter_ty = utils::setter_name(cx, path);
   utils::unwrap_impl_item(if field.count.node == 1 {
     quote_item!(cx,

--- a/ioreg/src/builder/setter.rs
+++ b/ioreg/src/builder/setter.rs
@@ -198,7 +198,7 @@ fn build_field_set_fn(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg,
   let unpacked_ty = utils::reg_primitive_type(cx, reg)
     .expect("Unexpected non-primitive register");
   let fn_name =
-    cx.ident_of((String::from_str("set_")+field.name.node.as_str()).as_str());
+    cx.ident_of((String::from("set_")+field.name.node.as_str()).as_str());
   let field_ty: P<ast::Ty> =
     cx.ty_path(utils::field_type_path(cx, path, reg, field));
   let mask = utils::mask(cx, field);
@@ -247,7 +247,7 @@ fn build_field_clear_fn(cx: &ExtCtxt, path: &Vec<String>,
 {
   let setter_ty = utils::setter_name(cx, path);
   let fn_name =
-    cx.ident_of((String::from_str("clear_")+field.name.node.as_str()).as_str());
+    cx.ident_of((String::from("clear_")+field.name.node.as_str()).as_str());
   let mask = utils::mask(cx, field);
 
   let field_doc = match field.docstring {

--- a/ioreg/src/lib.rs
+++ b/ioreg/src/lib.rs
@@ -327,7 +327,7 @@ N => NAME
 
 */
 
-#![feature(quote, plugin_registrar, rustc_private, collections, core)]
+#![feature(quote, plugin_registrar, rustc_private)]
 #![feature(convert)]
 #![feature(plugin)]
 

--- a/ioreg/src/node.rs
+++ b/ioreg/src/node.rs
@@ -133,8 +133,8 @@ impl Reg {
 
 /// Size of registers of register group in bytes
 pub fn regs_size(regs: &Vec<Reg>) -> u64 {
-  match regs.iter().max_by(|r| r.offset) {
-    Some(last) => last.offset + last.ty.size(),
+  match regs.iter().map(|r| r.offset + r.ty.size()).max() {
+    Some(last) => last,
     None => 0,
   }
 }

--- a/ioreg/src/parser.rs
+++ b/ioreg/src/parser.rs
@@ -506,7 +506,7 @@ impl<'a> Parser<'a> {
           self.bump();
           let stripped = s[prefix.len() ..]
             .trim_left_matches(' ');
-          docs.push(String::from_str(stripped));
+          docs.push(String::from(stripped));
         },
         _ => break,
       }

--- a/platformtree/src/builder/mod.rs
+++ b/platformtree/src/builder/mod.rs
@@ -159,7 +159,9 @@ impl Builder {
     ));
 
     let mut stmts = vec!(init_stack_stmt, init_data_stmt);
-    stmts.push_all(self.main_stmts.as_slice());
+    for s in self.main_stmts.clone().into_iter() {
+      stmts.push(s);
+    }
 
     let body = cx.block(DUMMY_SP, stmts, None);
 
@@ -219,7 +221,9 @@ impl Builder {
     let attr_no_mangle = cx.attribute(span, cx.meta_word(
         span, InternedString::new("no_mangle")));
     let mut attrs = vec!(attr_no_mangle);
-    attrs.push_all(local_attrs);
+    for a in local_attrs {
+      attrs.push(a.clone());
+    }
 
     P(ast::Item {
       ident: cx.ident_of(name),

--- a/platformtree/src/lib.rs
+++ b/platformtree/src/lib.rs
@@ -15,7 +15,7 @@
 
 //! Platform tree operations crate
 
-#![feature(quote, rustc_private, collections, alloc, hash, convert)]
+#![feature(quote, rustc_private, hash_default, convert, rc_weak)]
 
 // extern crate regex;
 extern crate syntax;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(asm, lang_items, plugin, core)]
+#![feature(asm, lang_items, plugin, core, core_intrinsics, core_prelude, range_inclusive, core_slice_ext)]
 #![allow(improper_ctypes)]
 #![deny(missing_docs)]
 #![no_std]

--- a/volatile_cell/lib.rs
+++ b/volatile_cell/lib.rs
@@ -15,7 +15,7 @@
 
 //! A cell that with volatile setter and getter.
 
-#![feature(core, no_std)]
+#![feature(core, no_std, core_intrinsics)]
 #![no_std]
 
 #[cfg(feature="replayer")] extern crate hamcrest;


### PR DESCRIPTION
* Some things got feature-gated
* `from_str` deprecated in favor of `From<T>`.
* rust-lang/rust#15311 caused possible rethinking of `max_by` and `min_by` on iterators.
* `Vec::push_all` feature-gated, but I replaced it so that we don't depend on **another** unstable feature.

It looks like it's a long road ahead before zinc will be able to track the stable channel or Rust.