### PR TITLE
Added toggle for the stm32f4 GPIO

### DIFF
--- a/src/hal/stm32f4/pin.rs
+++ b/src/hal/stm32f4/pin.rs
@@ -116,6 +116,15 @@ impl PinConf {
     self.get_reg().set_BSRR(bit);
   }
 
+  /// Toggles the GPIO value
+  pub fn toggle(&self) {
+    let bit: u32 = 1 << self.pin as usize;
+    let reg = self.get_reg();
+    let val: u32 = reg.ODR();
+
+    reg.set_ODR(val ^ bit);
+  }
+
   /// Returns input GPIO level.
   pub fn level(&self) -> ::hal::pin::GpioLevel {
     let bit: u32 = 1 << (self.pin as usize);


### PR DESCRIPTION
This adds the `toggle` function to the stm32f4's GPIO pins. This is a ported function from the HAL provided by STM:

```c
void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
{
  /* Check the parameters */
  assert_param(IS_GPIO_PIN(GPIO_Pin));

  GPIOx->ODR ^= GPIO_Pin;
}
```