### PR TITLE
Clarified how to build examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,6 @@ run `configure`:
 EXAMPLE_NAME=<example> make build
 ```
 
-Ouput will go to `target/<target-triple>/release/examples`.
+`EXAMPLE_NAME` is the name of the example *without* the `app_` prefix. For example, to build examples/app_blink.rs `EXAMPLE_NAME` should be `blink`.
+
+Output will go to `target/<target-triple>/release/examples`.


### PR DESCRIPTION
I initially couldn't get the examples to compile because `EXAMPLE_NAME` is the name without the `app_` prefix, so I though I would clarify it in the README.