### PR TITLE
Fix for removal of get_ident()

### DIFF
--- a/ioreg/src/builder/accessors.rs
+++ b/ioreg/src/builder/accessors.rs
@@ -83,7 +83,7 @@ fn build_field_accessors(cx: &ExtCtxt, path: &Vec<String>,
 
   let field_doc = match field.docstring {
     Some(ref d) => {
-      let s = token::get_ident(d.node);
+      let s = d.node.name.as_str();
       s.to_string()
     },
     None => "no documentation".to_string()

--- a/ioreg/src/builder/getter.rs
+++ b/ioreg/src/builder/getter.rs
@@ -75,7 +75,7 @@ fn build_type(cx: &ExtCtxt, path: &Vec<String>,
     .expect("Unexpected non-primitive register");
   let name = utils::getter_name(cx, path);
   let reg_doc = match reg.docstring {
-    Some(d) => token::get_ident(d.node).to_string(),
+    Some(d) => d.node.name.as_str(),
     None => "no documentation".to_string(),
   };
   let docstring = format!("`{}`: {}", reg.name.node, reg_doc);
@@ -220,7 +220,7 @@ fn build_field_get_fn(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg,
   };
   let docstring = format!("Get value of `{}` field: {}",
                           field.name.node,
-                          token::get_ident(field_doc));
+                          field_doc.name.as_str());
   let doc_attr = utils::doc_attribute(cx, utils::intern_string(cx, docstring));
 
   if field.count.node == 1 {

--- a/ioreg/src/builder/register.rs
+++ b/ioreg/src/builder/register.rs
@@ -138,7 +138,7 @@ fn build_reg_struct(cx: &ExtCtxt, path: &Vec<String>,
 fn build_enum_variant(cx: &ExtCtxt, variant: &node::Variant)
                       -> ast::Variant {
   let doc = match variant.docstring {
-    Some(d) => d.node.nameto_string(),
+    Some(d) => d.node.name.to_string(),
     None => "no documentation".to_string(),
   };
   let docstring = format!("`0x{:x}`. {}",

--- a/ioreg/src/builder/register.rs
+++ b/ioreg/src/builder/register.rs
@@ -111,7 +111,7 @@ fn build_reg_struct(cx: &ExtCtxt, path: &Vec<String>,
     .expect("Unexpected non-primitive reg");
 
   let reg_doc = match reg.docstring {
-    Some(d) => token::get_ident(d.node).to_string(),
+    Some(d) => d.node.name.to_string(),
     None => "no documentation".to_string(),
   };
   let docstring = format!("Register `{}`: {}",
@@ -138,7 +138,7 @@ fn build_reg_struct(cx: &ExtCtxt, path: &Vec<String>,
 fn build_enum_variant(cx: &ExtCtxt, variant: &node::Variant)
                       -> ast::Variant {
   let doc = match variant.docstring {
-    Some(d) => token::get_ident(d.node).to_string(),
+    Some(d) => d.node.nameto_string(),
     None => "no documentation".to_string(),
   };
   let docstring = format!("`0x{:x}`. {}",

--- a/ioreg/src/builder/setter.rs
+++ b/ioreg/src/builder/setter.rs
@@ -66,7 +66,7 @@ fn build_type(cx: &ExtCtxt, path: &Vec<String>,
   let reg_ty = cx.ty_ident(reg.name.span, utils::path_ident(cx, path));
 
   let reg_doc = match reg.docstring {
-    Some(d) => token::get_ident(d.node).to_string(),
+    Some(d) => d.node.name.to_string(),
     None => "no documentation".to_string(),
   };
   let docstring = format!("Update value of `{}` register: {}",
@@ -228,7 +228,7 @@ fn build_field_set_fn(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg,
   let mask = utils::mask(cx, field);
 
   let field_doc = match field.docstring {
-    Some(d) => token::get_ident(d.node).to_string(),
+    Some(d) => d.node.name.to_string(),
     None => "no documentation".to_string(),
   };
   let docstring = format!("Set value of `{}` field: {}",
@@ -275,7 +275,7 @@ fn build_field_clear_fn(cx: &ExtCtxt, path: &Vec<String>,
   let mask = utils::mask(cx, field);
 
   let field_doc = match field.docstring {
-    Some(d) => token::get_ident(d.node).to_string(),
+    Some(d) => d.node.name.to_string(),
     None => "no documentation".to_string(),
   };
   let docstring = format!("Clear `{}` flag: {}",

--- a/ioreg/src/builder/union.rs
+++ b/ioreg/src/builder/union.rs
@@ -120,7 +120,7 @@ impl<'a> BuildUnionTypes<'a> {
   fn build_reg_union_field(&self, path: &Vec<String>, reg: &node::Reg)
                            -> ast::StructField {
     let attrs = match reg.docstring {
-      Some(doc) => vec!(utils::doc_attribute(self.cx, token::get_ident(doc.node))),
+      Some(doc) => vec!(utils::doc_attribute(self.cx, doc.node.name.as_str())),
       None => Vec::new(),
     };
     let mut field_path = path.clone();
@@ -191,7 +191,7 @@ impl<'a> BuildUnionTypes<'a> {
     match reg.docstring {
       Some(docstring) =>
         attrs.push(
-          utils::doc_attribute(self.cx, token::get_ident(docstring.node))),
+          utils::doc_attribute(self.cx, docstring.node.name.as_str())),
       None => (),
     }
     let struct_item = P(ast::Item {

--- a/ioreg/src/builder/utils.rs
+++ b/ioreg/src/builder/utils.rs
@@ -167,5 +167,5 @@ pub fn getter_name(cx: &ExtCtxt, path: &Vec<String>) -> ast::Ident {
 }
 
 pub fn intern_string(cx: &ExtCtxt, s: String) -> token::InternedString {
-  token::get_ident(cx.ident_of(s.as_str()))
+  cx.ident_of(s.as_str()).name.as_str()
 }

--- a/ioreg/src/parser.rs
+++ b/ioreg/src/parser.rs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 use std::rc::{Rc};
+use std::ops::Deref;
 use syntax::ast::{Ident, TokenTree};
 use syntax::ast;
 use syntax::codemap::{Span, Spanned, respan, dummy_spanned, mk_sp};
@@ -514,7 +515,7 @@ impl<'a> Parser<'a> {
     loop {
       match self.token {
         token::DocComment(docstring) => {
-          let s = token::get_ident(docstring.ident());
+          let s = docstring.ident().name.as_str();
           if !s.starts_with(prefix) {
             break
           }
@@ -540,7 +541,7 @@ impl<'a> Parser<'a> {
     match self.token {
       token::Literal(token::Integer(n), suf) => {
         self.bump();
-        let lit = parse::integer_lit(n.as_str(),
+        let lit = parse::integer_lit(n.as_str().deref(),
                                      suf.as_ref().map(|n| n.as_str()),
                                      &self.sess.span_diagnostic,
                                      self.span);

--- a/macro_platformtree/src/lib.rs
+++ b/macro_platformtree/src/lib.rs
@@ -70,7 +70,7 @@ fn macro_zinc_task(cx: &mut ExtCtxt, _: Span, _: &ast::MetaItem,
     it: P<ast::Item>) -> P<ast::Item> {
   match it.node {
     ast::ItemFn(ref decl, style, constness, abi, _, ref block) => {
-      let istr = syntax::parse::token::get_ident(it.ident);
+      let istr = it.ident.name.as_str();
       let fn_name = &*istr;
       let ty_params = platformtree::builder::meta_args::get_ty_params_for_task(cx, fn_name);
 

--- a/platformtree/src/parser.rs
+++ b/platformtree/src/parser.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Deref;
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 use syntax::ast::{TokenTree, LitInt, UnsuffixedIntLit};
@@ -183,7 +184,7 @@ impl<'a> Parser<'a> {
       Token::Literal(token::Lit::Integer(intname), _) => {
         self.bump();
 
-        let lit = integer_lit(intname.as_str(), None, &self.sess.span_diagnostic, self.span);
+        let lit = integer_lit(intname.as_str().deref(), None, &self.sess.span_diagnostic, self.span);
         match lit {
           LitInt(i, _) => {
             format!("{}", i)
@@ -342,7 +343,7 @@ impl<'a> Parser<'a> {
       },
       Token::Literal(Lit::Integer(intname), suffix) => {
         if suffix.is_none() {
-          let lit = integer_lit(intname.as_str(), None, &self.sess.span_diagnostic, self.span);
+          let lit = integer_lit(intname.as_str().deref(), None, &self.sess.span_diagnostic, self.span);
           match lit {
             LitInt(i, UnsuffixedIntLit(_)) => {
               self.bump();
@@ -370,7 +371,7 @@ impl<'a> Parser<'a> {
       },
       token::Ident(ident, _) => {
         self.bump();
-        match &*token::get_ident(ident) {
+        match &*ident.name.as_str() {
           "true"  => Some(node::BoolValue(true)),
           "false" => Some(node::BoolValue(false)),
           other   => {


### PR DESCRIPTION
It may need testing, but this appears to fix the issue on my lpc17xx.

It also fixes two type errors in platformtree by using deref().