### PR TITLE
Fixes for rust nightly changes

### DIFF
--- a/examples/blink_k20/src/main.rs
+++ b/examples/blink_k20/src/main.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #![plugin(macro_zinc)]
 
-extern crate core;
 extern crate zinc;
 
 use core::option::Option::Some;

--- a/examples/blink_k20_isr/src/main.rs
+++ b/examples/blink_k20_isr/src/main.rs
@@ -1,7 +1,6 @@
 #![feature(no_std, core, start, core_intrinsics)]
 #![no_std]
 
-extern crate core;
 extern crate zinc;
 
 use core::intrinsics::volatile_load;

--- a/examples/blink_lpc17xx/src/main.rs
+++ b/examples/blink_lpc17xx/src/main.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #![plugin(macro_zinc)]
 
-extern crate core;
 extern crate zinc;
 
 use core::option::Option::Some;

--- a/examples/blink_pt/src/main.rs
+++ b/examples/blink_pt/src/main.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #![plugin(macro_platformtree)]
 
-extern crate core;
 extern crate zinc;
 
 platformtree!(

--- a/examples/blink_stm32f4/src/main.rs
+++ b/examples/blink_stm32f4/src/main.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #![plugin(macro_zinc)]
 
-extern crate core;
 extern crate zinc;
 
 use zinc::hal::timer::Timer;

--- a/examples/blink_stm32l1/src/main.rs
+++ b/examples/blink_stm32l1/src/main.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #![plugin(macro_zinc)]
 
-extern crate core;
 extern crate zinc;
 
 #[zinc_main]

--- a/examples/blink_tiva_c/src/main.rs
+++ b/examples/blink_tiva_c/src/main.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #![plugin(macro_platformtree)]
 
-extern crate core;
 extern crate zinc;
 
 platformtree!(

--- a/examples/bluenrg_stm32l1/src/main.rs
+++ b/examples/bluenrg_stm32l1/src/main.rs
@@ -4,7 +4,6 @@
 //! Sample application for BlueNRG communication over SPI in X-NUCLEO-IDB04A1
 //! extension board for NUCLEO-L152RE
 
-#[macro_use] extern crate core;
 extern crate zinc;
 
 use core::intrinsics::abort;

--- a/examples/dht22/src/main.rs
+++ b/examples/dht22/src/main.rs
@@ -3,7 +3,6 @@
 #![no_std]
 #![plugin(macro_platformtree)]
 
-extern crate core;
 extern crate zinc;
 #[macro_use] #[no_link] extern crate macro_platformtree;
 

--- a/examples/empty/src/main.rs
+++ b/examples/empty/src/main.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #![plugin(macro_zinc)]
 
-extern crate core;
 extern crate zinc;
 
 use zinc::hal::mem_init::{init_data, init_stack};

--- a/examples/lcd_tiva_c/src/main.rs
+++ b/examples/lcd_tiva_c/src/main.rs
@@ -3,7 +3,6 @@
 #![no_std]
 #![plugin(macro_platformtree)]
 
-extern crate core;
 extern crate zinc;
 #[macro_use] #[no_link] extern crate macro_platformtree;
 

--- a/examples/uart/src/main.rs
+++ b/examples/uart/src/main.rs
@@ -3,7 +3,6 @@
 #![no_std]
 #![plugin(macro_platformtree)]
 
-extern crate core;
 extern crate zinc;
 #[macro_use] #[no_link] extern crate macro_platformtree;
 

--- a/examples/uart_tiva_c/src/main.rs
+++ b/examples/uart_tiva_c/src/main.rs
@@ -3,7 +3,6 @@
 #![no_std]
 #![plugin(macro_platformtree)]
 
-extern crate core;
 extern crate zinc;
 #[macro_use] #[no_link] extern crate macro_platformtree;
 

--- a/examples/usart_stm32l1/src/main.rs
+++ b/examples/usart_stm32l1/src/main.rs
@@ -2,7 +2,6 @@
 #![no_std]
 #![plugin(macro_zinc)]
 
-extern crate core;
 extern crate zinc;
 
 #[zinc_main]

--- a/ioreg/tests/test.rs
+++ b/ioreg/tests/test.rs
@@ -19,6 +19,7 @@
 #![plugin(ioreg)]
 
 extern crate volatile_cell;
+extern crate core;
 
 #[cfg(test)]
 mod test {

--- a/ioreg/tests/test.rs
+++ b/ioreg/tests/test.rs
@@ -18,7 +18,6 @@
 #![feature(core, plugin)]
 #![plugin(ioreg)]
 
-extern crate core;
 extern crate volatile_cell;
 
 #[cfg(test)]

--- a/platformtree/src/builder/meta_args.rs
+++ b/platformtree/src/builder/meta_args.rs
@@ -19,7 +19,7 @@ use syntax::ext::base::ExtCtxt;
 use syntax::ext::build::AstBuilder;
 use syntax::parse::token::{InternedString, intern_and_get_ident};
 use syntax::ptr::P;
-use std::hash::{hash, SipHasher};
+use std::hash::{Hash, Hasher, SipHasher};
 
 static TAG: &'static str = "__zinc_task_ty_params";
 
@@ -29,7 +29,9 @@ pub trait ToTyHash {
 
 impl ToTyHash for String {
   fn to_tyhash(&self) -> String {
-    let h: u64 = hash::<_, SipHasher>(&self);
+    let mut s = SipHasher::new();
+    self.hash(&mut s);
+    let h: u64 = s.finish();
     format!("Ty{:X}", h)
   }
 }

--- a/platformtree/src/lib.rs
+++ b/platformtree/src/lib.rs
@@ -15,7 +15,7 @@
 
 //! Platform tree operations crate
 
-#![feature(quote, rustc_private, hash_default, convert, rc_weak)]
+#![feature(quote, rustc_private, convert, rc_weak)]
 
 // extern crate regex;
 extern crate syntax;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 #![feature(asm, lang_items, plugin, range_inclusive)]
 #![feature(core, core_intrinsics, core_prelude, core_slice_ext, core_str_ext)]
 #![allow(improper_ctypes)]
+#![feature(const_fn)]
 #![deny(missing_docs)]
 #![no_std]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@ STM32F403/407).
 #![plugin(ioreg)]
 #![feature(no_std)]
 
-#[macro_use] extern crate core;
 #[cfg(target_os = "none")]
 extern crate rlibc;
 

--- a/src/os/cond_var.rs
+++ b/src/os/cond_var.rs
@@ -21,7 +21,6 @@ pub use os::cond_var::internal::{CondVar, COND_VAR_INIT};
 mod internal {
   use core::option::{None, Some};
   use core::ty::Unsafe;
-  use core::marker;
   use core::marker::Sync;
 
   use hal::cortex_m3::sched::NoInterrupts;
@@ -92,7 +91,6 @@ mod internal {
 
 #[cfg(not(multitasking))]
 mod internal {
-  use core::marker;
   use core::marker::Sync;
   use core::cell::UnsafeCell;
 
@@ -101,13 +99,11 @@ mod internal {
   /// A condition variable
   pub struct CondVar {
     waiting: UnsafeCell<bool>,
-    nocopy: marker::NoCopy
   }
 
   /// Static initializer
   pub const COND_VAR_INIT: CondVar = CondVar {
-    waiting: UnsafeCell { value: false },
-    nocopy: marker::NoCopy,
+    waiting: UnsafeCell::new(false),
   };
 
   impl CondVar {
@@ -115,7 +111,6 @@ mod internal {
     pub fn new() -> CondVar {
       CondVar {
         waiting: UnsafeCell::new(false),
-        nocopy: marker::NoCopy,
       }
     }
 

--- a/src/os/mutex.rs
+++ b/src/os/mutex.rs
@@ -37,10 +37,10 @@ mod internal {
 
   /// Static initializer
   pub const MUTEX_INIT: Mutex = Mutex {
-    owner: UnsafeCell {value: None},
+    owner: UnsafeCell::new(None),
     waiting: Queue {
-      head: UnsafeCell {value: 0 as *mut Node<*mut TaskDescriptor>,},
-      tail: UnsafeCell {value: 0 as *mut Node<*mut TaskDescriptor>,},
+      head: UnsafeCell::new(0 as *mut Node<*mut TaskDescriptor>),
+      tail: UnsafeCell::new(0 as *mut Node<*mut TaskDescriptor>),
     }
   };
 
@@ -153,7 +153,7 @@ mod internal {
   }
 
   /// Static initializer
-  pub const MUTEX_INIT: Mutex = Mutex { taken: UnsafeCell { value: false  } };
+  pub const MUTEX_INIT: Mutex = Mutex { taken: UnsafeCell::new(false) };
 
   /// A mutex lock
   #[must_use]

--- a/src/util/app.rs
+++ b/src/util/app.rs
@@ -20,7 +20,6 @@
 #![crate_type="staticlib"]
 #![no_std]
 
-extern crate core;
 extern crate zinc;
 extern crate app;
 

--- a/volatile_cell/lib.rs
+++ b/volatile_cell/lib.rs
@@ -15,10 +15,9 @@
 
 //! A cell that with volatile setter and getter.
 
-#![feature(core, no_std, core_intrinsics)]
+#![feature(no_std, core_intrinsics)]
 #![no_std]
 
-extern crate core;
 
 #[cfg(feature="replayer")] #[macro_use(expect)] extern crate expectest;
 #[cfg(feature="replayer")] #[macro_use] extern crate std;


### PR DESCRIPTION
As described at https://github.com/rust-lang/rfcs/pull/1184, rustc nightly now automatically imports core when using no_std