### PR TITLE
A few ioregs! fixes

### DIFF
--- a/examples/blink_k20/src/main.rs
+++ b/examples/blink_k20/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start, core_intrinsics)]
+#![feature(plugin, no_std)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/examples/blink_k20_isr/src/main.rs
+++ b/examples/blink_k20_isr/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(no_std, core, start, core_intrinsics)]
+#![feature(no_std, start, core_intrinsics)]
 #![no_std]
 
 extern crate zinc;

--- a/examples/blink_lpc17xx/src/main.rs
+++ b/examples/blink_lpc17xx/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start, core_intrinsics)]
+#![feature(plugin, no_std)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/examples/blink_pt/src/main.rs
+++ b/examples/blink_pt/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start, core_intrinsics)]
+#![feature(plugin, no_std, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_platformtree)]
 

--- a/examples/blink_stm32f4/src/main.rs
+++ b/examples/blink_stm32f4/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start, core_intrinsics)]
+#![feature(plugin, no_std)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/examples/blink_stm32l1/src/main.rs
+++ b/examples/blink_stm32l1/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start, core_intrinsics)]
+#![feature(plugin, no_std)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/examples/blink_tiva_c/src/main.rs
+++ b/examples/blink_tiva_c/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start, core_intrinsics)]
+#![feature(plugin, no_std, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_platformtree)]
 

--- a/examples/bluenrg_stm32l1/src/main.rs
+++ b/examples/bluenrg_stm32l1/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(no_std, core, start, core_intrinsics)]
+#![feature(no_std, start, core_intrinsics)]
 #![no_std]
 
 //! Sample application for BlueNRG communication over SPI in X-NUCLEO-IDB04A1
@@ -7,11 +7,6 @@
 extern crate zinc;
 
 use core::intrinsics::abort;
-// "curious module hack" - a workaround for `fmt` module being looked in `std`
-// by the `write!` macro
-mod std {
-  pub use core::fmt;
-}
 
 #[start]
 fn start(_: isize, _: *const *const u8) -> isize {

--- a/examples/dht22/src/main.rs
+++ b/examples/dht22/src/main.rs
@@ -1,10 +1,8 @@
-#![feature(start, plugin, no_std, core, core_intrinsics)]
-#![crate_type="staticlib"]
+#![feature(start, plugin, no_std, core_intrinsics)]
 #![no_std]
 #![plugin(macro_platformtree)]
 
 extern crate zinc;
-#[macro_use] #[no_link] extern crate macro_platformtree;
 
 use core::option::Option::{Some, None};
 

--- a/examples/empty/src/main.rs
+++ b/examples/empty/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(core, plugin, asm, no_std, start, core_intrinsics)]
+#![feature(plugin, no_std, asm)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/examples/lcd_tiva_c/src/main.rs
+++ b/examples/lcd_tiva_c/src/main.rs
@@ -1,10 +1,8 @@
-#![feature(plugin, no_std, core, start, core_intrinsics)]
-#![crate_type="staticlib"]
+#![feature(plugin, no_std, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_platformtree)]
 
 extern crate zinc;
-#[macro_use] #[no_link] extern crate macro_platformtree;
 
 use zinc::drivers::chario::CharIO;
 use zinc::drivers::lcd::hd44780u::{Hd44780u, Font};

--- a/examples/uart/src/main.rs
+++ b/examples/uart/src/main.rs
@@ -1,10 +1,8 @@
-#![feature(start, plugin, no_std, core, core_intrinsics)]
-#![crate_type="staticlib"]
+#![feature(start, plugin, no_std, core_intrinsics)]
 #![no_std]
 #![plugin(macro_platformtree)]
 
 extern crate zinc;
-#[macro_use] #[no_link] extern crate macro_platformtree;
 
 platformtree!(
   lpc17xx@mcu {

--- a/examples/uart_tiva_c/src/main.rs
+++ b/examples/uart_tiva_c/src/main.rs
@@ -1,10 +1,8 @@
-#![feature(plugin, no_std, core, start, core_intrinsics)]
-#![crate_type="staticlib"]
+#![feature(plugin, no_std, start, core_intrinsics)]
 #![no_std]
 #![plugin(macro_platformtree)]
 
 extern crate zinc;
-#[macro_use] #[no_link] extern crate macro_platformtree;
 
 use zinc::drivers::chario::CharIO;
 

--- a/examples/usart_stm32l1/src/main.rs
+++ b/examples/usart_stm32l1/src/main.rs
@@ -1,4 +1,4 @@
-#![feature(plugin, no_std, core, start, core_intrinsics)]
+#![feature(plugin, no_std)]
 #![no_std]
 #![plugin(macro_zinc)]
 

--- a/ioreg/src/builder/accessors.rs
+++ b/ioreg/src/builder/accessors.rs
@@ -116,6 +116,7 @@ fn build_get_fn(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg)
     impl $reg_ty {
       $doc_attr
       #[allow(dead_code)]
+      #[inline(always)]
       pub fn get(&self) -> $getter_ty {
         $getter_ty::new(self)
       }
@@ -139,6 +140,7 @@ fn build_ignoring_state_setter_fn(cx: &ExtCtxt, path: &Vec<String>, reg: &node::
     impl $reg_ty {
       $doc_attr
       #[allow(dead_code)]
+      #[inline(always)]
       pub fn ignoring_state(&self) -> $setter_ty {
         $setter_ty::new_ignoring_state(self)
       }
@@ -161,6 +163,7 @@ fn build_field_set_fn(cx: &ExtCtxt, path: &Vec<String>,
     utils::unwrap_impl_item(quote_item!(cx,
       impl $reg_ty {
         #[allow(dead_code, missing_docs)]
+        #[inline(always)]
         pub fn $fn_name<'a>(&'a self, new_value: $field_ty) -> $setter_ty<'a> {
           let mut setter: $setter_ty = $setter_ty::new(self);
           setter.$fn_name(new_value);
@@ -172,6 +175,7 @@ fn build_field_set_fn(cx: &ExtCtxt, path: &Vec<String>,
     utils::unwrap_impl_item(quote_item!(cx,
       impl $reg_ty {
         #[allow(dead_code, missing_docs)]
+        #[inline(always)]
         pub fn $fn_name<'a>(&'a self, idx: usize, new_value: $field_ty) -> $setter_ty<'a> {
           let mut setter: $setter_ty = $setter_ty::new(self);
           setter.$fn_name(idx, new_value);
@@ -196,6 +200,7 @@ fn build_field_get_fn(cx: &ExtCtxt, path: &Vec<String>,
         quote_item!(cx,
           impl $reg_ty {
             #[allow(dead_code, missing_docs)]
+            #[inline(always)]
             pub fn $fn_name(&self) -> $field_ty {
               $getter_ty::new(self).$fn_name()
             }
@@ -205,6 +210,7 @@ fn build_field_get_fn(cx: &ExtCtxt, path: &Vec<String>,
         quote_item!(cx,
           impl $reg_ty {
             #[allow(dead_code, missing_docs)]
+            #[inline(always)]
             pub fn $fn_name(&self, idx: usize) -> $field_ty {
               $getter_ty::new(self).$fn_name(idx)
             }
@@ -226,6 +232,7 @@ fn build_field_clear_fn(cx: &ExtCtxt, path: &Vec<String>,
     quote_item!(cx,
       impl $reg_ty {
         #[allow(dead_code, missing_docs)]
+        #[inline(always)]
         pub fn $fn_name<'a>(&'a self) -> $setter_ty<'a> {
           let mut setter: $setter_ty = $setter_ty::new(self);
           setter.$fn_name();
@@ -237,6 +244,7 @@ fn build_field_clear_fn(cx: &ExtCtxt, path: &Vec<String>,
     quote_item!(cx,
       impl $reg_ty {
         #[allow(dead_code, missing_docs)]
+        #[inline(always)]
         pub fn $fn_name<'a>(&'a self, idx: usize) -> $setter_ty<'a> {
           let mut setter: $setter_ty = $setter_ty::new(self);
           setter.$fn_name(idx);

--- a/ioreg/src/builder/getter.rs
+++ b/ioreg/src/builder/getter.rs
@@ -103,6 +103,7 @@ fn build_new(cx: &ExtCtxt, path: &Vec<String>,
   let item = quote_item!(cx,
     impl $getter_ty {
       #[doc = "Create a getter reflecting the current value of the given register."]
+      #[inline(always)]
       pub fn new(reg: & $reg_ty) -> $getter_ty {
         $getter_ident {
           value: reg.value.get(),
@@ -186,6 +187,7 @@ fn build_impl(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg,
   let get_raw: P<ast::ImplItem> = utils::unwrap_impl_item(quote_item!(cx,
     impl $getter_ty {
       #[doc = "Get the raw value of the register."]
+      #[inline(always)]
       pub fn raw(&self) -> $packed_ty {
         self.value
       }
@@ -194,6 +196,7 @@ fn build_impl(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg,
 
   let it = quote_item!(cx,
     #[allow(dead_code)]
+    #[inline(always)]
     impl $getter_ty {
       $new
       $getters
@@ -230,6 +233,7 @@ fn build_field_get_fn(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg,
     utils::unwrap_impl_item(quote_item!(cx,
       impl X {
         $doc_attr
+        #[inline(always)]
         pub fn $fn_name(&self) -> $field_ty {
           $value
         }

--- a/ioreg/src/builder/getter.rs
+++ b/ioreg/src/builder/getter.rs
@@ -130,7 +130,7 @@ fn from_primitive(cx: &ExtCtxt, path: &Vec<String>, _: &node::Reg,
       for v in vars.iter() {
         let mut name = path.clone();
         name.push(field.name.node.clone());
-        let enum_ident = cx.ident_of(name.connect("_").as_str());
+        let enum_ident = cx.ident_of(name.join("_").as_str());
         let val_ident = cx.ident_of(v.name.node.as_str());
         let body = cx.expr_path(
           cx.path(v.name.span, vec!(enum_ident, val_ident)));

--- a/ioreg/src/builder/register.rs
+++ b/ioreg/src/builder/register.rs
@@ -123,6 +123,7 @@ fn build_reg_struct(cx: &ExtCtxt, path: &Vec<String>,
     $doc_attr
     #[derive(Clone)]
     #[allow(non_camel_case_types)]
+    #[repr(C)]
     pub struct $ty_name {
       value: VolatileCell<$packed_ty>,
     }

--- a/ioreg/src/builder/register.rs
+++ b/ioreg/src/builder/register.rs
@@ -75,7 +75,7 @@ fn build_field_type(cx: &ExtCtxt, path: &Vec<String>,
         variants: FromIterator::from_iter(
           variants.iter().map(|v| P(build_enum_variant(cx, v)))),
       };
-      let attrs: Vec<ast::Attribute> = vec!(
+      let mut attrs: Vec<ast::Attribute> = vec!(
         utils::list_attribute(cx, "derive",
                               vec!("PartialEq"),
                               field.name.span),
@@ -84,6 +84,19 @@ fn build_field_type(cx: &ExtCtxt, path: &Vec<String>,
                                    "non_camel_case_types",
                                    "missing_docs"),
                               field.name.span));
+      
+      // setting the enum's repr to the width of the register
+      // (unless there's only 1 variant; in which case we omit 
+      // the repr attribute due to E0083
+      if variants.len() > 1 {
+        let enum_repr = utils::reg_primitive_type_name(reg)
+          .expect("Unexpected non-primitive reg");
+        
+        attrs.push(utils::list_attribute(cx, "repr",
+                                         vec!(enum_repr),
+                                         field.name.span));
+      }
+      
       let ty_item: P<ast::Item> = P(ast::Item {
         ident: name,
         id: ast::DUMMY_NODE_ID,

--- a/ioreg/src/builder/setter.rs
+++ b/ioreg/src/builder/setter.rs
@@ -96,6 +96,7 @@ fn build_new<'a>(cx: &'a ExtCtxt, path: &Vec<String>, reg: &node::Reg)
   utils::unwrap_impl_item(quote_item!(cx,
     impl<'a> $setter_ident<'a> {
       #[doc="Create a new updater"]
+      #[inline(always)]
       pub fn new(reg: &'a $reg_ty) -> $setter_ident<'a> {
         $setter_ident {
           value: 0,
@@ -116,6 +117,7 @@ fn build_new_ignoring_state<'a>(cx: &'a ExtCtxt, path: &Vec<String>,
   utils::unwrap_impl_item(quote_item!(cx,
     impl<'a> $setter_ident<'a> {
       #[doc="Create a new updater that ignores current state"]
+      #[inline(always)]
       pub fn new_ignoring_state(reg: &'a $reg_ty) -> $setter_ident<'a> {
         $setter_ident {
           value: 0,
@@ -159,6 +161,7 @@ fn build_drop(cx: &ExtCtxt, path: &Vec<String>,
   let item = quote_item!(cx,
     #[doc = "This performs the register update"]
     impl<'a> Drop for $setter_ident<'a> {
+      #[inline(always)]
       fn drop(&mut self) {
         let clear_mask: $unpacked_ty = $clear as $unpacked_ty;
         if self.mask != 0 {
@@ -176,6 +179,7 @@ fn build_done(ctx: &ExtCtxt, path: &Vec<String>) -> P<ast::ImplItem> {
   utils::unwrap_impl_item(quote_item!(ctx,
     impl<'a> $setter_ident<'a> {
       #[doc = "Commit changes to register. Allows for chaining of set"]
+      #[inline(always)]
       pub fn done(self) {}
     }
   ).unwrap())
@@ -194,6 +198,7 @@ fn build_impl(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg,
   let done = build_done(cx, path);
   quote_item!(cx,
     #[allow(dead_code)]
+    #[inline(always)]
     impl<'a> $setter_ident<'a> {
       $new
       $new_is
@@ -240,6 +245,7 @@ fn build_field_set_fn(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg,
     utils::unwrap_impl_item(quote_item!(cx,
       impl<'a> $setter_ty<'a> {
         $doc_attr
+        #[inline(always)]
         pub fn $fn_name<'b>(&'b mut self,
                             new_value: $field_ty) -> &'b mut $setter_ty<'a> {
           self.value |= (self.value & ! $mask) | ((new_value as $unpacked_ty) & $mask) << $shift;
@@ -253,6 +259,7 @@ fn build_field_set_fn(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg,
     utils::unwrap_impl_item(quote_item!(cx,
       impl<'a> $setter_ty<'a> {
         $doc_attr
+        #[inline(always)]
         pub fn $fn_name<'b>(&'b mut self,
                             idx: usize,
                             new_value: $field_ty) -> &'b mut $setter_ty<'a> {
@@ -287,6 +294,7 @@ fn build_field_clear_fn(cx: &ExtCtxt, path: &Vec<String>,
     utils::unwrap_impl_item(quote_item!(cx,
       impl<'a> $setter_ty<'a> {
         $doc_attr
+        #[inline(always)]
         pub fn $fn_name<'b>(&'b mut self) -> &'b mut $setter_ty<'a> {
           self.value |= $mask << $shift;
           self.mask |= $mask << $shift;
@@ -299,6 +307,7 @@ fn build_field_clear_fn(cx: &ExtCtxt, path: &Vec<String>,
     utils::unwrap_impl_item(quote_item!(cx,
       impl<'a> $setter_ty<'a> {
         $doc_attr
+        #[inline(always)]
         pub fn $fn_name<'b>(&'b mut self, idx: usize) -> &'b mut $setter_ty<'a> {
           self.value |= $mask << $shift;
           self.mask |= $mask << $shift;

--- a/ioreg/src/builder/setter.rs
+++ b/ioreg/src/builder/setter.rs
@@ -248,7 +248,7 @@ fn build_field_set_fn(cx: &ExtCtxt, path: &Vec<String>, reg: &node::Reg,
         #[inline(always)]
         pub fn $fn_name<'b>(&'b mut self,
                             new_value: $field_ty) -> &'b mut $setter_ty<'a> {
-          self.value |= (self.value & ! $mask) | ((new_value as $unpacked_ty) & $mask) << $shift;
+          self.value = (self.value & !($mask << $shift)) | ((new_value as $unpacked_ty) & $mask) << $shift;
           self.mask |= $mask << $shift;
           self
         }

--- a/ioreg/src/builder/union.rs
+++ b/ioreg/src/builder/union.rs
@@ -186,6 +186,9 @@ impl<'a> BuildUnionTypes<'a> {
                                  "dead_code",
                                  "missing_docs"),
                             reg.name.span),
+      utils::list_attribute(self.cx, "repr",
+                            vec!("C"),
+                            reg.name.span),
     );
     match reg.docstring {
       Some(docstring) =>

--- a/ioreg/src/builder/union.rs
+++ b/ioreg/src/builder/union.rs
@@ -243,6 +243,7 @@ impl<'a> BuildUnionTypes<'a> {
     let item_getter = quote_item!(self.cx,
       #[allow(non_snake_case, dead_code)]
       $doc_attr
+      #[inline(always)]
       pub fn $name() -> &'static $name {
           unsafe { ::core::intrinsics::transmute($item_address as usize) }
       }

--- a/ioreg/src/builder/utils.rs
+++ b/ioreg/src/builder/utils.rs
@@ -70,13 +70,17 @@ pub fn doc_attribute(cx: &ExtCtxt, docstring: token::InternedString)
   cx.attribute(DUMMY_SP, attr)
 }
 
-pub fn primitive_type_path(cx: &ExtCtxt, width: &Spanned<node::RegWidth>)
-                           -> ast::Path {
-  let name = match width.node {
+pub fn primitive_type_name(width: node::RegWidth) -> &'static str {
+  match width {
     node::RegWidth::Reg8  => "u8",
     node::RegWidth::Reg16 => "u16",
     node::RegWidth::Reg32 => "u32",
-  };
+  }
+}
+
+pub fn primitive_type_path(cx: &ExtCtxt, width: &Spanned<node::RegWidth>)
+                           -> ast::Path {
+  let name = primitive_type_name(width.node);
   cx.path_ident(width.span, cx.ident_of(name))
 }
 
@@ -86,6 +90,13 @@ pub fn reg_primitive_type_path(cx: &ExtCtxt, reg: &node::Reg)
                                -> Option<ast::Path> {
   match reg.ty {
     node::RegType::RegPrim(ref width, _) => Some(primitive_type_path(cx, width)),
+    _ => None,
+  }
+}
+
+pub fn reg_primitive_type_name(reg: &node::Reg) -> Option<&'static str> {
+  match reg.ty {
+    node::RegType::RegPrim(ref width, _) => Some(primitive_type_name(width.node)),
     _ => None,
   }
 }

--- a/ioreg/src/builder/utils.rs
+++ b/ioreg/src/builder/utils.rs
@@ -33,7 +33,7 @@ pub fn expr_int(cx: &ExtCtxt, n: Spanned<i64>) -> P<ast::Expr> {
 /// The name of the structure representing a register
 pub fn path_ident(cx: &ExtCtxt, path: &Vec<String>)
                       -> ast::Ident {
-  cx.ident_of(path.clone().connect("_").as_str())
+  cx.ident_of(path.clone().join("_").as_str())
 }
 
 
@@ -115,7 +115,7 @@ pub fn field_type_path(cx: &ExtCtxt, path: &Vec<String>,
         &None => {
           let mut name = path.clone();
           name.push(field.name.node.clone());
-          cx.path_ident(span, cx.ident_of(name.connect("_").as_str()))
+          cx.path_ident(span, cx.ident_of(name.join("_").as_str()))
         }
       }
     },

--- a/ioreg/src/parser.rs
+++ b/ioreg/src/parser.rs
@@ -528,7 +528,7 @@ impl<'a> Parser<'a> {
         _ => break,
       }
     }
-    let string = docs.connect("\n");
+    let string = docs.join("\n");
     let string = string.as_str().trim();
     if !string.is_empty() {
       Some(respan(self.last_span, self.cx.ident_of(string)))

--- a/ioreg/tests/test.rs
+++ b/ioreg/tests/test.rs
@@ -92,6 +92,24 @@ mod test {
     assert_eq!(get_value(&test, 2), 0xdead<<16);
   }
 
+  #[test]
+  fn set_field_twice() {
+    let test: BASIC_TEST = zeroed_safe();
+    
+    test.reg1.set_field3(0xAA).set_field3(0x55);
+    assert_eq!(test.reg1.field3(), 0x55);
+  }
+
+  #[test]
+  fn set_independent_fields() {
+    let test: BASIC_TEST = zeroed_safe();
+    
+    test.reg1.set_field2(0b010).set_field3(0xf0);
+    
+    assert_eq!(test.reg1.field2(), 0b010);
+    assert_eq!(test.reg1.field3(), 0xf0);
+  }
+
   /*
      describe!(
      before_each {

--- a/macro_platformtree/src/lib.rs
+++ b/macro_platformtree/src/lib.rs
@@ -27,7 +27,7 @@ use rustc::plugin::Registry;
 use syntax::ast;
 use syntax::codemap::DUMMY_SP;
 use syntax::codemap::Span;
-use syntax::ext::base::{ExtCtxt, MacResult, Modifier};
+use syntax::ext::base::{ExtCtxt, MacResult, MultiModifier, Annotatable};
 use syntax::ext::build::AstBuilder;
 use syntax::owned_slice::OwnedSlice;
 use syntax::print::pprust;
@@ -43,7 +43,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
   reg.register_macro("platformtree", macro_platformtree);
   reg.register_macro("platformtree_verbose", macro_platformtree_verbose);
   reg.register_syntax_extension(syntax::parse::token::intern("zinc_task"),
-      Modifier(Box::new(macro_zinc_task)));
+      MultiModifier(Box::new(macro_zinc_task)));
 }
 
 pub fn macro_platformtree(cx: &mut ExtCtxt, _: Span, tts: &[ast::TokenTree])
@@ -67,7 +67,14 @@ pub fn macro_platformtree_verbose(cx: &mut ExtCtxt, sp: Span,
 }
 
 fn macro_zinc_task(cx: &mut ExtCtxt, _: Span, _: &ast::MetaItem,
-    it: P<ast::Item>) -> P<ast::Item> {
+    ann: Annotatable) -> Annotatable {
+  match ann {
+    Annotatable::Item(it) => {Annotatable::Item(macro_zinc_task_item(cx, it))}
+    other     => {other}
+  }
+}
+
+fn macro_zinc_task_item(cx: &mut ExtCtxt, it: P<ast::Item>) -> P<ast::Item> {
   match it.node {
     ast::ItemFn(ref decl, style, constness, abi, _, ref block) => {
       let istr = it.ident.name.as_str();

--- a/platformtree/src/builder/mod.rs
+++ b/platformtree/src/builder/mod.rs
@@ -253,10 +253,10 @@ impl ToTokens for TokenString {
 
 pub fn add_node_dependency(node: &Rc<node::Node>, dep: &Rc<node::Node>) {
   let mut depends_on = node.depends_on.borrow_mut();
-  depends_on.deref_mut().push(dep.downgrade());
+  depends_on.deref_mut().push(Rc::downgrade(dep));
 
   let mut rev_depends_on = dep.rev_depends_on.borrow_mut();
-  rev_depends_on.push(node.downgrade());
+  rev_depends_on.push(Rc::downgrade(node));
 }
 
 #[cfg(test)]

--- a/platformtree/src/node.rs
+++ b/platformtree/src/node.rs
@@ -106,7 +106,7 @@ impl Subnodes {
   ///
   /// The node must not be present in the subnodes.
   pub fn push(&mut self, node: Rc<Node>) {
-    let weak = node.downgrade();
+    let weak = Rc::downgrade(&node);
     self.by_path.insert(node.path.clone(), weak);
     self.by_index.push(node);
   }

--- a/platformtree/src/parser.rs
+++ b/platformtree/src/parser.rs
@@ -126,7 +126,7 @@ impl<'a> Parser<'a> {
                 "previously defined here");
             return false;
           } else {
-            map.insert(name.clone(), n.downgrade());
+            map.insert(name.clone(), Rc::downgrade(n));
           }
         },
         None => (),
@@ -205,7 +205,7 @@ impl<'a> Parser<'a> {
 
     let node = Rc::new(node::Node::new(
         node_name, node_span, node_path, node_path_span, parent));
-    let weak_node = node.downgrade();
+    let weak_node = Rc::downgrade(&node);
 
     //    we're here
     //             |

--- a/platformtree/src/test_helpers.rs
+++ b/platformtree/src/test_helpers.rs
@@ -79,7 +79,8 @@ pub fn with_parsed_tts<F>(src: &str, block: F)
     recursion_limit: 10,
     trace_mac: true,
   };
-  let mut cx = ExtCtxt::new(&parse_sess, cfg, ecfg);
+  let mut gated_cfgs = vec!();
+  let mut cx = ExtCtxt::new(&parse_sess, cfg, ecfg, &mut gated_cfgs);
   cx.bt_push(ExpnInfo {
     call_site: mk_sp(BytePos(0), BytePos(0)),
     callee: NameAndSpan {

--- a/src/drivers/lcd/hd44780u.rs
+++ b/src/drivers/lcd/hd44780u.rs
@@ -15,8 +15,6 @@
 
 //! Driver for the Hitachi HD44780U LCD driver
 
-use core::prelude::*;
-
 use drivers::chario::CharIO;
 use hal::pin::Gpio;
 use hal::timer::Timer;

--- a/src/hal/lpc17xx/pin_pt.rs
+++ b/src/hal/lpc17xx/pin_pt.rs
@@ -107,7 +107,7 @@ fn build_pin(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
               cx.parse_sess().span_diagnostic.span_err(
                   node.get_attr("function").value_span,
                   format!("unknown pin function `{}`, allowed functions: {}",
-                      fun, avaliable.connect(", ")).as_str());
+                      fun, avaliable.join(", ")).as_str());
               return;
             },
             Some(func_idx) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 #![feature(asm, lang_items, plugin, range_inclusive)]
-#![feature(core, core_intrinsics, core_prelude, core_slice_ext, core_str_ext)]
+#![feature(core_intrinsics, core_slice_ext, core_str_ext)]
 #![allow(improper_ctypes)]
 #![feature(const_fn)]
 #![deny(missing_docs)]

--- a/src/util/support.rs
+++ b/src/util/support.rs
@@ -18,7 +18,6 @@
 pub use core::intrinsics::breakpoint;
 
 /// Call the debugger and halts execution.
-#[no_stack_check]
 #[no_mangle]
 pub extern fn abort() -> ! {
   unsafe {
@@ -30,7 +29,6 @@ pub extern fn abort() -> ! {
 // TODO(bgamari): This is only necessary for exception handling and
 // can be removed when we have this issue resolved.
 #[doc(hidden)]
-#[no_stack_check]
 #[no_mangle]
 pub extern fn __aeabi_memset(dest: *mut u8, size: usize, value: u32) {
   unsafe {
@@ -40,7 +38,6 @@ pub extern fn __aeabi_memset(dest: *mut u8, size: usize, value: u32) {
 }
 
 #[doc(hidden)]
-#[no_stack_check]
 #[no_mangle]
 pub extern fn __aeabi_memclr(dest: *mut u8, size: usize) {
   unsafe {

--- a/volatile_cell/lib.rs
+++ b/volatile_cell/lib.rs
@@ -37,6 +37,7 @@
 /// This structure is used to represent a hardware register.
 /// It is mostly used by the ioreg family of macros.
 #[derive(Copy, Clone)]
+#[repr(C)]
 pub struct VolatileCell<T> {
   value: T,
 }


### PR DESCRIPTION
Fixed a few issues with `ioregs!` generated code:

* Generated register types are now marked `#[repr(C)]`.
* Generated accessor functions are now marked `#[inline(always)]`, yielding in one case a code size reduction from "doesn't fit in 128KB" to less than 200 bytes.
* Fixed an issue where calling a field's "set" method twice on the same `Update` struct would cause the bits to be ORed together instead of the second one replacing the first.