### PR TITLE
A couple of minor changes to make code compatible with current rust nightly

### DIFF
--- a/ioreg/src/parser.rs
+++ b/ioreg/src/parser.rs
@@ -515,7 +515,7 @@ impl<'a> Parser<'a> {
     loop {
       match self.token {
         token::DocComment(docstring) => {
-          let s = docstring.ident().name.as_str();
+          let s = docstring.as_str();
           if !s.starts_with(prefix) {
             break
           }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 #![feature(asm, lang_items, plugin, range_inclusive)]
-#![feature(core_intrinsics, core_slice_ext, core_str_ext)]
+#![feature(core_intrinsics, core_slice_ext)]
 #![allow(improper_ctypes)]
 #![feature(const_fn)]
 #![deny(missing_docs)]


### PR DESCRIPTION
Trying to build blink_stmf3f4 I came across a couple of minor tweaks to get the code to compile with the current nightly "rustc 1.5.0-nightly (81b3b27cf 2015-10-11)"