### PR TITLE
Various nightly fixes.

### DIFF
--- a/ioreg/src/builder/register.rs
+++ b/ioreg/src/builder/register.rs
@@ -84,19 +84,19 @@ fn build_field_type(cx: &ExtCtxt, path: &Vec<String>,
                                    "non_camel_case_types",
                                    "missing_docs"),
                               field.name.span));
-      
+
       // setting the enum's repr to the width of the register
-      // (unless there's only 1 variant; in which case we omit 
+      // (unless there's only 1 variant; in which case we omit
       // the repr attribute due to E0083
       if variants.len() > 1 {
         let enum_repr = utils::reg_primitive_type_name(reg)
           .expect("Unexpected non-primitive reg");
-        
+
         attrs.push(utils::list_attribute(cx, "repr",
                                          vec!(enum_repr),
                                          field.name.span));
       }
-      
+
       let ty_item: P<ast::Item> = P(ast::Item {
         ident: name,
         id: ast::DUMMY_NODE_ID,
@@ -163,11 +163,9 @@ fn build_enum_variant(cx: &ExtCtxt, variant: &node::Variant)
     ast::Variant_ {
       name: cx.ident_of(variant.name.node.as_str()),
       attrs: vec!(doc_attr),
-      kind: ast::TupleVariantKind(Vec::new()),
-      id: ast::DUMMY_NODE_ID,
+      data: P(ast::VariantData::Tuple(Vec::new(), ast::DUMMY_NODE_ID)),
       disr_expr: Some(utils::expr_int(cx, respan(variant.value.span,
                                                  variant.value.node as i64))),
-      vis: ast::Inherited,
     }
   )
 }

--- a/ioreg/src/lib.rs
+++ b/ioreg/src/lib.rs
@@ -342,6 +342,7 @@ use syntax::ptr::P;
 use syntax::codemap::Span;
 use syntax::ext::base::{ExtCtxt, MacResult};
 use syntax::util::small_vector::SmallVector;
+use syntax::print::pprust::item_to_string;
 
 pub mod node;
 pub mod parser;
@@ -350,6 +351,7 @@ pub mod builder;
 #[plugin_registrar]
 pub fn plugin_registrar(reg: &mut Registry) {
   reg.register_macro("ioregs", macro_ioregs);
+  reg.register_macro("ioregs_debug", macro_ioregs_debug);
 }
 
 pub fn macro_ioregs(cx: &mut ExtCtxt, _: Span, tts: &[ast::TokenTree])
@@ -358,6 +360,23 @@ pub fn macro_ioregs(cx: &mut ExtCtxt, _: Span, tts: &[ast::TokenTree])
     Some(group) => {
       let mut builder = builder::Builder::new();
       let items = builder.emit_items(cx, group);
+      MacItems::new(items)
+    },
+    None => {
+      panic!("Parsing failed");
+    }
+  }
+}
+
+pub fn macro_ioregs_debug(cx: &mut ExtCtxt, _: Span, tts: &[ast::TokenTree])
+                    -> Box<MacResult+'static> {
+  match parser::Parser::new(cx, tts).parse_ioregs() {
+    Some(group) => {
+      let mut builder = builder::Builder::new();
+      let items = builder.emit_items(cx, group);
+      for ref i in &items {
+        println!("{}", item_to_string(i));
+      }
       MacItems::new(items)
     },
     None => {

--- a/ioreg/src/parser.rs
+++ b/ioreg/src/parser.rs
@@ -515,7 +515,7 @@ impl<'a> Parser<'a> {
     loop {
       match self.token {
         token::DocComment(docstring) => {
-          let s = docstring.ident().name.as_str();
+          let s = docstring.as_str();
           if !s.starts_with(prefix) {
             break
           }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 #![feature(asm, lang_items, plugin, range_inclusive)]
-#![feature(core_intrinsics, core_slice_ext, core_str_ext)]
+#![feature(core_intrinsics, core_slice_ext)]
 #![allow(improper_ctypes)]
 #![feature(const_fn)]
 #![deny(missing_docs)]


### PR DESCRIPTION
This fixes a few things broken for #347 apart from one:

```diff
index 71ba8aa..ede9605 100644
--- a/ioreg/src/builder/union.rs
+++ b/ioreg/src/builder/union.rs
@@ -176,10 +176,9 @@ impl<'a> BuildUnionTypes<'a> {
     let padded_regs = PaddedRegsIterator::new(&mut regs);
     let fields =
       padded_regs.enumerate().map(|(n,r)| self.build_pad_or_reg(path, r, n));
-    let struct_def = ast::StructDef {
-      fields: FromIterator::from_iter(fields),
-      ctor_id: None,
-    };
+    let struct_def = ast::VariantData::Struct(
+        FromIterator::from_iter(fields),
+        ast::DUMMY_NODE_ID);
     let mut attrs: Vec<ast::Attribute> = vec!(
       utils::list_attribute(self.cx, "allow",
                             vec!("non_camel_case_types",
```

breaks ioreg with `error: empty tuple structs and enum variants are not allowed, use unit structs and enum variants instead`.