### PR TITLE
Attempt to copy iomem.ld to $OUT_DIR only if it exists

### DIFF
--- a/src/hal/lpc11xx/iomem.ld
+++ b/src/hal/lpc11xx/iomem.ld
@@ -1,1 +1,0 @@
-/* lpc11xx uses placement ioregs */


### PR DESCRIPTION
This allows removing empty iomem.ld files from the repository.
Eventually all examples will be migrated to ioregs! macros and the code
snippet from build.rs can be removed.