### PR TITLE
Create proper isr_cortex_m0 module

### DIFF
--- a/src/hal/cortex_m0/isr.rs
+++ b/src/hal/cortex_m0/isr.rs
@@ -1,0 +1,85 @@
+// Zinc, the bare metal stack for rust.
+// Copyright 2014 Vladimir "farcaller" Pouzanov <farcaller@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::option::Option;
+use core::option::Option::{Some, None};
+
+extern {
+  fn main();
+  fn __STACK_BASE();
+
+  fn isr_nmi();
+  fn isr_hardfault();
+
+  fn isr_svcall();
+  fn isr_pendsv();
+  fn isr_systick();
+}
+
+#[no_mangle]
+pub unsafe extern fn isr_handler_wrapper() {
+  asm!(".weak isr_nmi, isr_hardfault
+      .weak isr_svcall, isr_pendsv, isr_systick
+
+      .thumb_func
+      isr_nmi:
+
+      .thumb_func
+      isr_hardfault:
+
+      .thumb_func
+      isr_svcall:
+
+      .thumb_func
+      isr_pendsv:
+
+      .thumb_func
+      isr_systick:
+
+      b isr_default_fault
+
+      .thumb_func
+      isr_default_fault:
+      mrs r0, psp
+      mrs r1, msp
+      ldr r2, [r0, 0x18]
+      ldr r3, [r1, 0x18]
+      bkpt" :::: "volatile");
+}
+
+#[allow(non_upper_case_globals)]
+const ISRCount: usize = 16;
+
+#[link_section=".isr_vector"]
+#[allow(non_upper_case_globals)]
+#[no_mangle]
+pub static ISRVectors: [Option<unsafe extern fn()>; ISRCount] = [
+  Some(__STACK_BASE),
+  Some(main),             // 1: Reset
+  Some(isr_nmi),          // 2: NMI
+  Some(isr_hardfault),    // 3: Hard Fault
+  None,                   // Reserved
+  None,                   // Reserved
+  None,                   // Reserved
+  None,                   // Reserved
+  None,                   // Reserved
+  None,                   // Reserved
+  None,                   // Reserved
+  Some(isr_svcall),       // 11: SVCall
+  None,                   // Reserved
+  None,                   // Reserved
+  Some(isr_pendsv),       // 14: PendSV
+  Some(isr_systick),      // 15: SysTick
+];

--- a/src/hal/isr.rs
+++ b/src/hal/isr.rs
@@ -19,7 +19,7 @@
 #![allow(missing_docs)]
 
 #[cfg(feature = "cpu_cortex-m0")]
-#[path="cortex_m3/isr.rs"] pub mod isr_cortex_m0;
+#[path="cortex_m0/isr.rs"] pub mod isr_cortex_m0;
 
 #[cfg(feature = "cpu_cortex-m3")]
 #[path="cortex_m3/isr.rs"] pub mod isr_cortex_m3;

--- a/src/hal/lpc11xx/layout.ld
+++ b/src/hal/lpc11xx/layout.ld
@@ -1,7 +1,5 @@
 __STACK_BASE  = 0x10002000;
 
-isr_reserved_1 = 0 - (__STACK_BASE + main + 1 + isr_nmi + 1 + isr_hardfault + 1);
-
 _data_load = LOADADDR(.data);
 
 ENTRY(main)


### PR DESCRIPTION
Instead of reusing module from Cortex-M3, create specific module for M0,
containing only exceptions documented on the ARMv6-M Architecture
Reference Manual.

This allows removing the unnecessary "isr_reserved_1" symbol from the
linker scripts for Cortex-M0 based boards and setting reserved ISR vector entries.