### PR TITLE
thumbv6m-none-eabi target rename and cleanup

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,4 @@
-[target.thumbv6-none-eabi]
+[target.thumbv6m-none-eabi]
 linker = "arm-none-eabi-gcc"
 ar = "arm-none-eabi-ar"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ mcu_k20 = ["cpu_cortex-m4"]
 mcu_tiva_c = ["cpu_cortex-m4"]
 multitasking = ["cpu_cortex-m4"]
 
-[target.thumbv6-none-eabi.dependencies.core]
+[target.thumbv6m-none-eabi.dependencies.core]
 git = "https://github.com/hackndev/rust-libcore"
 
 [target.thumbv7m-none-eabi.dependencies.core]

--- a/support/build-jenkins.sh
+++ b/support/build-jenkins.sh
@@ -35,7 +35,7 @@ else
   # build cross-compiled lib and examples
   case "$PLATFORM" in
     lpc11xx )
-      TARGET=thumbv6-none-eabi
+      TARGET=thumbv6m-none-eabi
       EXAMPLES="empty"
       ;;
     lpc17xx )

--- a/thumbv6m-none-eabi.json
+++ b/thumbv6m-none-eabi.json
@@ -4,7 +4,7 @@
     "data-layout": "e-m:e-p:32:32-i1:8:32-i8:8:32-i16:16:32-i64:64-v128:64:128-a:0:32-n32-S64",
     "disable-redzone": true,
     "executables": true,
-    "llvm-target": "thumbv6-none-eabi",
+    "llvm-target": "thumbv6m-none-eabi",
     "morestack": false,
     "os": "none",
     "relocation-model": "static",

--- a/thumbv6m-none-eabi.json
+++ b/thumbv6m-none-eabi.json
@@ -1,21 +1,21 @@
 {
-    "arch": "arm",
-    "cpu": "cortex-m0",
-    "data-layout": "e-m:e-p:32:32-i1:8:32-i8:8:32-i16:16:32-i64:64-v128:64:128-a:0:32-n32-S64",
-    "disable-redzone": true,
-    "executables": true,
     "llvm-target": "thumbv6m-none-eabi",
-    "morestack": false,
-    "os": "none",
-    "relocation-model": "static",
     "target-endian": "little",
     "target-pointer-width": "32",
-    "no-compiler-rt": true,
+    "os": "none",
+    "env": "eabi",
+    "vendor": "unknown",
+    "arch": "arm",
+
+    "data-layout": "e-m:e-p:32:32-i64:64-v128:64:128-a:0:32-n32-S64",
     "pre-link-args": [
-        "-mcpu=cortex-m0", "-mthumb",
         "-Tlayout.ld"
     ],
     "post-link-args": [
         "-lm", "-lgcc", "-lnosys"
-    ]
+    ],
+    "cpu": "cortex-m0",
+    "executables": true,
+    "relocation-model": "static",
+    "no-compiler-rt": true
 }

--- a/volatile_cell/Cargo.toml
+++ b/volatile_cell/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["rlib"]
 [features]
 replayer = ["expectest"]
 
-[target.thumbv6-none-eabi.dependencies.core]
+[target.thumbv6m-none-eabi.dependencies.core]
 git = "https://github.com/hackndev/rust-libcore"
 
 [target.thumbv7m-none-eabi.dependencies.core]


### PR DESCRIPTION
See individual commit messages for details. This PR will probably fail to build until https://github.com/hackndev/rlibc/pull/2 is merged.