### PR TITLE
Added ADC support for lpc17xx

### DIFF
--- a/examples/adc_lpc17xx/Cargo.toml
+++ b/examples/adc_lpc17xx/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "adc"
+version = "0.0.1"
+
+[features]
+default = ["mcu_lpc17xx"]
+mcu_lpc17xx = ["zinc/mcu_lpc17xx"]
+
+[dependencies]
+zinc = { path =  "../.." }
+macro_platformtree = { path = "../../macro_platformtree" }
+rust-libcore = "*"

--- a/examples/adc_lpc17xx/src/main.rs
+++ b/examples/adc_lpc17xx/src/main.rs
@@ -1,0 +1,74 @@
+// ADC example for lpc17xx chips
+// Copyright 2015 Felix Obenhuber <felix@obenhuber.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(start, plugin, core_intrinsics)]
+#![no_std]
+#![plugin(macro_platformtree)]
+
+extern crate zinc;
+
+use zinc::hal::pin::{Adc, Gpio};
+use zinc::hal::timer::Timer;
+
+platformtree!(
+    lpc17xx@mcu {
+        clock {
+            source = "main-oscillator";
+            source_frequency = 12_000_000;
+            pll {
+                m = 50;
+                n = 3;
+                divisor = 4;
+            }
+        }
+
+        timer {
+            timer@1 {
+                counter = 25;
+                divisor = 4;
+            }
+        }
+
+        gpio {
+            0 {
+                led@22 { direction = "out"; }
+                adc0@23 { direction = "out"; function = "ad0_0"; }
+            }
+        }
+    }
+
+    os {
+        single_task {
+            loop = "run";
+            args {
+                adc0 = &adc0;
+                led = &led;
+                timer = &timer;
+            }
+        }
+    }
+);
+
+fn run(args: &pt::run_args) {
+    loop {
+        if args.adc0.read() > 2048 {
+            args.led.set_high();
+        } else {
+            args.led.set_low();
+        }
+        args.timer.wait_ms(100);
+    }
+}
+

--- a/src/hal/lpc17xx/iomem.ld
+++ b/src/hal/lpc17xx/iomem.ld
@@ -54,8 +54,18 @@ lpc17xx_iomem_PINSEL7   = 0x4002C01C;
 lpc17xx_iomem_PINSEL9   = 0x4002C024;
 lpc17xx_iomem_PINSEL10  = 0x4002C028;
 
+lpc17xx_iomem_PINMODE0  = 0x4002C040;
+lpc17xx_iomem_PINMODE1  = 0x4002C044;
+lpc17xx_iomem_PINMODE2  = 0x4002C048;
+lpc17xx_iomem_PINMODE3  = 0x4002C04C;
+lpc17xx_iomem_PINMODE4  = 0x4002C050;
+lpc17xx_iomem_PINMODE7  = 0x4002C05C;
+lpc17xx_iomem_PINMODE9  = 0x4002C064;
+
 lpc17xx_iomem_SSP1      = 0x40030000;
 lpc17xx_iomem_SSP0      = 0x40088000;
+
+lpc17xx_iomem_ADC       = 0x40034000;
 
 lpc17xx_iomem_TIMER2    = 0x40090000;
 lpc17xx_iomem_TIMER3    = 0x40094000;

--- a/src/hal/pin.rs
+++ b/src/hal/pin.rs
@@ -51,3 +51,9 @@ pub trait Gpio {
   /// for reading or writing respectively.
   fn set_direction(&self, new_mode: GpioDirection);
 }
+
+/// Analog Input
+pub trait Adc {
+  /// Read analog input value
+  fn read(&self) -> u32;
+}

--- a/support/build-jenkins.sh
+++ b/support/build-jenkins.sh
@@ -40,7 +40,7 @@ else
       ;;
     lpc17xx )
       TARGET=thumbv7m-none-eabi
-      EXAMPLES="empty blink_lpc17xx blink_pt uart dht22 rgb_pwm_lpc17xx"
+      EXAMPLES="empty blink_lpc17xx blink_pt uart dht22 rgb_pwm_lpc17xx adc_lpc17xx"
       ;;
     k20 )
       TARGET=thumbv7em-none-eabi


### PR DESCRIPTION
Added support for the adc channels of the lpc17xx. The setup and read sequence is borrowed from mbed. Tested on a LPCxpresso 1796 board. This patch also adds some lines to configure the pin modes - not yet integrated in the pt - but needed for adc pins. 