### PR TITLE
Avoid double definition when used in test

### DIFF
--- a/src/util/lang_items.rs
+++ b/src/util/lang_items.rs
@@ -13,22 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(feature = "test")))]
 use core::fmt::Arguments;
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(feature = "test")))]
 #[lang="stack_exhausted"]
 extern fn stack_exhausted() {}
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(feature = "test")))]
 #[lang="eh_personality"]
 extern fn eh_personality() {}
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(feature = "test")))]
 #[lang="begin_unwind"]
 extern fn begin_unwind() {}
 
-#[cfg(not(test))]
+#[cfg(all(not(test), not(feature = "test")))]
 #[lang="panic_fmt"]
 pub fn panic_fmt(_fmt: &Arguments, _file_line: &(&'static str, usize)) -> ! {
   loop { }


### PR DESCRIPTION
When zinc is used and a test is added to the application, some functions are double defined because building with tests always includes std. This patch avoids that by omitting these functions when feature test is set. I forward test from the application to zinc:
[features]                                                                                                                                                                                                                                                                                                                                                                                                                                   test = ["zinc/test"]  