### PR TITLE
Add default targets to examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ autom4te.cache
 Makefile
 /cov
 *.pyc
-/examples/*/*.json

--- a/examples/adc_lpc17xx/.cargo/config
+++ b/examples/adc_lpc17xx/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7m-none-eabi"

--- a/examples/adc_lpc17xx/thumbv7m-none-eabi.json
+++ b/examples/adc_lpc17xx/thumbv7m-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7m-none-eabi.json

--- a/examples/blink_k20/.cargo/config
+++ b/examples/blink_k20/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"

--- a/examples/blink_k20/thumbv7em-none-eabi.json
+++ b/examples/blink_k20/thumbv7em-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7em-none-eabi.json

--- a/examples/blink_k20_isr/.cargo/config
+++ b/examples/blink_k20_isr/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"

--- a/examples/blink_k20_isr/thumbv7em-none-eabi.json
+++ b/examples/blink_k20_isr/thumbv7em-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7em-none-eabi.json

--- a/examples/blink_lpc17xx/.cargo/config
+++ b/examples/blink_lpc17xx/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7m-none-eabi"

--- a/examples/blink_lpc17xx/thumbv7m-none-eabi.json
+++ b/examples/blink_lpc17xx/thumbv7m-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7m-none-eabi.json

--- a/examples/blink_pt/.cargo/config
+++ b/examples/blink_pt/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7m-none-eabi"

--- a/examples/blink_pt/thumbv7m-none-eabi.json
+++ b/examples/blink_pt/thumbv7m-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7m-none-eabi.json

--- a/examples/blink_stm32f4/.cargo/config
+++ b/examples/blink_stm32f4/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"

--- a/examples/blink_stm32f4/thumbv7em-none-eabi.json
+++ b/examples/blink_stm32f4/thumbv7em-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7em-none-eabi.json

--- a/examples/blink_stm32l1/.cargo/config
+++ b/examples/blink_stm32l1/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7m-none-eabi"

--- a/examples/blink_stm32l1/thumbv7m-none-eabi.json
+++ b/examples/blink_stm32l1/thumbv7m-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7m-none-eabi.json

--- a/examples/blink_tiva_c/.cargo/config
+++ b/examples/blink_tiva_c/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"

--- a/examples/blink_tiva_c/thumbv7em-none-eabi.json
+++ b/examples/blink_tiva_c/thumbv7em-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7em-none-eabi.json

--- a/examples/bluenrg_stm32l1/.cargo/config
+++ b/examples/bluenrg_stm32l1/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7m-none-eabi"

--- a/examples/bluenrg_stm32l1/thumbv7m-none-eabi.json
+++ b/examples/bluenrg_stm32l1/thumbv7m-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7m-none-eabi.json

--- a/examples/dht22/.cargo/config
+++ b/examples/dht22/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7m-none-eabi"

--- a/examples/dht22/thumbv7m-none-eabi.json
+++ b/examples/dht22/thumbv7m-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7m-none-eabi.json

--- a/examples/empty/thumbv6m-none-eabi.json
+++ b/examples/empty/thumbv6m-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv6m-none-eabi.json

--- a/examples/empty/thumbv7em-none-eabi.json
+++ b/examples/empty/thumbv7em-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7em-none-eabi.json

--- a/examples/empty/thumbv7m-none-eabi.json
+++ b/examples/empty/thumbv7m-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7m-none-eabi.json

--- a/examples/rgb_pwm_lpc17xx/.cargo/config
+++ b/examples/rgb_pwm_lpc17xx/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7m-none-eabi"

--- a/examples/rgb_pwm_lpc17xx/thumbv7m-none-eabi.json
+++ b/examples/rgb_pwm_lpc17xx/thumbv7m-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7m-none-eabi.json

--- a/examples/uart/.cargo/config
+++ b/examples/uart/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7m-none-eabi"

--- a/examples/uart/thumbv7m-none-eabi.json
+++ b/examples/uart/thumbv7m-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7m-none-eabi.json

--- a/examples/uart_tiva_c/.cargo/config
+++ b/examples/uart_tiva_c/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7em-none-eabi"

--- a/examples/uart_tiva_c/thumbv7em-none-eabi.json
+++ b/examples/uart_tiva_c/thumbv7em-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7em-none-eabi.json

--- a/examples/usart_stm32l1/.cargo/config
+++ b/examples/usart_stm32l1/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "thumbv7m-none-eabi"

--- a/examples/usart_stm32l1/thumbv7m-none-eabi.json
+++ b/examples/usart_stm32l1/thumbv7m-none-eabi.json
@@ -1,0 +1,1 @@
+../../thumbv7m-none-eabi.json

--- a/support/build-jenkins.sh
+++ b/support/build-jenkins.sh
@@ -60,7 +60,6 @@ else
 
   for e in $EXAMPLES; do
     pushd "examples/$e"
-    ln -sf "../../$TARGET.json"
     cargo build --target=$TARGET --verbose --features "mcu_$PLATFORM" --release
     popd
   done


### PR DESCRIPTION
Besides adding default targets I also added symlinks to JSON target specs. I'm not sure whether it is the most correct way but it enables building the examples out of box. User doesn't have to tediously create them and there is no problem having multiple targets (symlinks) in one example (e.g. as in the _empty_ example).

There is also possibility of setting **RUST_TARGET_PATH** to the folder with target specs. This doesn't allow building out of box but the user doesn't have to create new symlink for each example she/he wants to build.