### PR TITLE
Reflect the move of TokenTree

### DIFF
--- a/ioreg/src/lib.rs
+++ b/ioreg/src/lib.rs
@@ -336,6 +336,7 @@ extern crate rustc_plugin;
 
 use rustc_plugin::Registry;
 use syntax::ast;
+use syntax::tokenstream;
 use syntax::ptr::P;
 use syntax::codemap::Span;
 use syntax::ext::base::{ExtCtxt, MacResult};
@@ -352,7 +353,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
   reg.register_macro("ioregs_debug", macro_ioregs_debug);
 }
 
-pub fn macro_ioregs(cx: &mut ExtCtxt, _: Span, tts: &[ast::TokenTree])
+pub fn macro_ioregs(cx: &mut ExtCtxt, _: Span, tts: &[tokenstream::TokenTree])
                     -> Box<MacResult+'static> {
   match parser::Parser::new(cx, tts).parse_ioregs() {
     Some(group) => {
@@ -366,7 +367,7 @@ pub fn macro_ioregs(cx: &mut ExtCtxt, _: Span, tts: &[ast::TokenTree])
   }
 }
 
-pub fn macro_ioregs_debug(cx: &mut ExtCtxt, _: Span, tts: &[ast::TokenTree])
+pub fn macro_ioregs_debug(cx: &mut ExtCtxt, _: Span, tts: &[tokenstream::TokenTree])
                     -> Box<MacResult+'static> {
   match parser::Parser::new(cx, tts).parse_ioregs() {
     Some(group) => {

--- a/ioreg/src/parser.rs
+++ b/ioreg/src/parser.rs
@@ -15,7 +15,8 @@
 
 use std::rc::{Rc};
 use std::ops::Deref;
-use syntax::ast::{Ident, TokenTree};
+use syntax::ast::Ident;
+use syntax::tokenstream::TokenTree;
 use syntax::ast;
 use syntax::codemap::{Span, Spanned, respan, dummy_spanned, mk_sp};
 use syntax::ext::base::ExtCtxt;

--- a/macro_platformtree/src/lib.rs
+++ b/macro_platformtree/src/lib.rs
@@ -26,6 +26,7 @@ use std::ops::Deref;
 
 use rustc_plugin::Registry;
 use syntax::ast;
+use syntax::tokenstream;
 use syntax::codemap::DUMMY_SP;
 use syntax::codemap::Span;
 use syntax::ext::base::{ExtCtxt, MacResult, MultiModifier, Annotatable};
@@ -46,7 +47,7 @@ pub fn plugin_registrar(reg: &mut Registry) {
       MultiModifier(Box::new(macro_zinc_task)));
 }
 
-pub fn macro_platformtree(cx: &mut ExtCtxt, _: Span, tts: &[ast::TokenTree])
+pub fn macro_platformtree(cx: &mut ExtCtxt, _: Span, tts: &[tokenstream::TokenTree])
     -> Box<MacResult+'static> {
   let pt = Parser::new(cx, tts).parse_platformtree();
   let items = Builder::build(cx, pt.unwrap())
@@ -56,7 +57,7 @@ pub fn macro_platformtree(cx: &mut ExtCtxt, _: Span, tts: &[ast::TokenTree])
 }
 
 pub fn macro_platformtree_verbose(cx: &mut ExtCtxt, sp: Span,
-    tts: &[ast::TokenTree]) -> Box<MacResult+'static> {
+    tts: &[tokenstream::TokenTree]) -> Box<MacResult+'static> {
   let result = macro_platformtree(cx, sp, tts);
   println!("Platform Tree dump:");
   for i in result.make_items().unwrap().as_slice().iter() {

--- a/platformtree/src/builder/mod.rs
+++ b/platformtree/src/builder/mod.rs
@@ -16,7 +16,7 @@
 use std::rc::Rc;
 use std::ops::DerefMut;
 use syntax::abi;
-use syntax::ast::TokenTree;
+use syntax::tokenstream::TokenTree;
 use syntax::ast;
 use syntax::codemap::{Span, DUMMY_SP};
 use syntax::ext::base::ExtCtxt;
@@ -162,7 +162,7 @@ impl Builder {
       stmts.push(s);
     }
 
-    let body = cx.block(DUMMY_SP, stmts, None);
+    let body = cx.block(DUMMY_SP, stmts);
 
     let unused_variables = cx.meta_word(DUMMY_SP,
         InternedString::new("unused_variables"));
@@ -193,7 +193,7 @@ impl Builder {
         // zinc::os::task::morestack();
     ));
     let empty_span = DUMMY_SP;
-    let body = cx.block(empty_span, vec!(stmt), None);
+    let body = cx.block(empty_span, vec!(stmt));
     self.item_fn(cx, empty_span, "__morestack", &[], body)
   }
 

--- a/platformtree/src/parser.rs
+++ b/platformtree/src/parser.rs
@@ -16,7 +16,8 @@
 use std::ops::Deref;
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
-use syntax::ast::{TokenTree, LitKind, LitIntType};
+use syntax::ast::{LitKind, LitIntType};
+use syntax::tokenstream::TokenTree;
 use syntax::codemap::{Span, mk_sp};
 use syntax::ext::base::ExtCtxt;
 use syntax::parse::{token, ParseSess, lexer, integer_lit};


### PR DESCRIPTION
In the latest rust nightly TokenTree was moved out of syntax::ast into syntax::tokenstream
This changes the ioreg code accordingly.