### PR TITLE
Fixed missing key in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 rust: nightly
 before_install:
     - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
+    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 6D1D8367A3421AFB
     - sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/terry_guo-gcc-arm-embedded-precise.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
     - sudo apt-get install gcc-arm-none-eabi libcurl4-openssl-dev libelf-dev libdw-dev
     - wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz && tar xzf master.tar.gz


### PR DESCRIPTION
This fixes the travis file so the build is done.
Solves #382 

Note that zinc does not compile correctly. 