### PR TITLE
blink_stm32f4: Fix timer

### DIFF
--- a/examples/blink_stm32f4/src/main.rs
+++ b/examples/blink_stm32f4/src/main.rs
@@ -26,7 +26,7 @@ pub fn main() {
   led1.setup();
   led2.setup();
 
-  let timer = timer::Timer::new(timer::TimerPeripheral::Timer2, 25u32);
+  let timer = timer::Timer::new(timer::TimerPeripheral::Timer2, 16u32);
 
   loop {
     led1.set_high();


### PR DESCRIPTION
This example runs using the HSI clock which is 16 MHz. This means
that we need to pass 16 in rather than 25.

I confirmed (with my Logic analyzer) that with this patch that the
timings are correct on the STM32FDISC board which uses an STM32F407.