### PR TITLE
Fix platform tree for Tiva C/Stellaris Launchpad boards

### DIFF
--- a/platformtree/Cargo.toml
+++ b/platformtree/Cargo.toml
@@ -7,5 +7,8 @@ authors = ["Zinc Developers <zinc@github.com>"]
 name = "platformtree"
 plugin = true
 
+[dependencies]
+regex = "*"
+
 [dev-dependencies.hamcrest]
 git = "https://github.com/carllerche/hamcrest-rust.git"

--- a/platformtree/Cargo.toml
+++ b/platformtree/Cargo.toml
@@ -3,9 +3,6 @@ name = "platformtree"
 version = "0.1.0"
 authors = ["Zinc Developers <zinc@github.com>"]
 
-[dependencies]
-regex = "0.1"
-
 [lib]
 name = "platformtree"
 plugin = true

--- a/platformtree/Cargo.toml
+++ b/platformtree/Cargo.toml
@@ -3,6 +3,9 @@ name = "platformtree"
 version = "0.1.0"
 authors = ["Zinc Developers <zinc@github.com>"]
 
+[dependencies]
+regex = "0.1"
+
 [lib]
 name = "platformtree"
 plugin = true

--- a/platformtree/src/builder/mcu.rs
+++ b/platformtree/src/builder/mcu.rs
@@ -17,7 +17,7 @@ use std::rc::Rc;
 use syntax::ext::base::ExtCtxt;
 
 use lpc17xx_pt;
-// use tiva_c_pt;
+use tiva_c_pt;
 use node;
 
 use super::Builder;
@@ -27,7 +27,7 @@ pub fn attach(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
     Some(ref name) => {
       match name.as_str() {
         "lpc17xx" => lpc17xx_pt::attach(builder, cx, node.clone()),
-        // "tiva_c"  => tiva_c_pt::attach(builder, cx, node.clone()),
+        "tiva_c"  => tiva_c_pt::attach(builder, cx, node.clone()),
         _ => node.materializer.set(Some(fail_build_mcu as fn(&mut Builder, &mut ExtCtxt, Rc<node::Node>))),
       }
     },

--- a/platformtree/src/lib.rs
+++ b/platformtree/src/lib.rs
@@ -19,6 +19,7 @@
 
 // extern crate regex;
 extern crate syntax;
+extern crate regex;
 #[cfg(test)] extern crate hamcrest;
 
 pub mod builder;
@@ -26,7 +27,7 @@ pub mod node;
 pub mod parser;
 
 #[path="../../src/hal/lpc17xx/platformtree.rs"] mod lpc17xx_pt;
-// #[path="../zinc/hal/tiva_c/platformtree.rs"] mod tiva_c_pt;
+#[path="../../src/hal/tiva_c/platformtree.rs"] mod tiva_c_pt;
 #[path="../../src/drivers/drivers_pt.rs"] mod drivers_pt;
 
 #[cfg(test)] mod test_helpers;

--- a/platformtree/src/lib.rs
+++ b/platformtree/src/lib.rs
@@ -19,6 +19,7 @@
 
 // extern crate regex;
 extern crate syntax;
+extern crate regex;
 #[cfg(test)] extern crate hamcrest;
 
 pub mod builder;

--- a/platformtree/src/lib.rs
+++ b/platformtree/src/lib.rs
@@ -19,7 +19,6 @@
 
 // extern crate regex;
 extern crate syntax;
-extern crate regex;
 #[cfg(test)] extern crate hamcrest;
 
 pub mod builder;

--- a/src/hal/tiva_c/pin.rs
+++ b/src/hal/tiva_c/pin.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 //! Pin configuration
 //! Allows GPIO configuration
 //! Pin muxing not implemented yet.

--- a/src/hal/tiva_c/pin_pt.rs
+++ b/src/hal/tiva_c/pin_pt.rs
@@ -38,7 +38,7 @@ pub fn verify(_: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
 
 fn get_port_id(s: &str) -> Option<char> {
     match s.len() {
-        1 => match s.chars().nth(0).unwrap().to_uppercase() {
+        1 => match s.chars().nth(0).unwrap().to_uppercase().nth(0).unwrap() {
             p @ 'A'...'F' => Some(p),
             _             => None,
         },
@@ -50,16 +50,16 @@ fn build_pin(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
   let port_node = node.parent.clone().unwrap().upgrade().unwrap();
   let ref port_path = port_node.path;
 
-  let error = |&: err: &str | {
+  let error = |err: &str | {
     cx.parse_sess().span_diagnostic.span_err(port_node.path_span, err);
   };
 
-  let port_str = format!("Port{}", match get_port_id(port_path.as_slice()) {
+  let port_str = format!("Port{}", match get_port_id(port_path.as_str()) {
     Some(port) => port,
     None => {
       cx.parse_sess().span_diagnostic.span_err(port_node.path_span,
           format!("unknown port `{}`, allowed values: a...f",
-                  port_path).as_slice());
+                  port_path).as_str());
       return;
     }
   });
@@ -72,12 +72,12 @@ fn build_pin(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
   }
 
   let direction_str =
-    match node.get_string_attr("direction").unwrap().as_slice() {
+    match node.get_string_attr("direction").unwrap().as_str() {
       "out" => "zinc::hal::pin::Out",
       "in"  => "zinc::hal::pin::In",
       bad   => {
         error(format!("unknown direction `{}`, allowed values: `in`, `out`",
-                      bad).as_slice());
+                      bad).as_str());
         return;
       }
     };
@@ -89,11 +89,11 @@ fn build_pin(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
     Some(f)    => f as u8,
   };
 
-  let pin_str = match node.path.as_slice().parse::<usize>().unwrap() {
+  let pin_str = match node.path.as_str().parse::<usize>().unwrap() {
     0 ...7  => &node.path,
     other  => {
       error(format!("unknown pin `{}`, allowed values: 0...7",
-                    other).as_slice());
+                    other).as_str());
       return;
     }
   };
@@ -111,5 +111,5 @@ fn build_pin(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
           $direction,
           $function);
   );
-  builder.add_main_statement(st);
+  builder.add_main_statement(st.unwrap());
 }

--- a/src/hal/tiva_c/platformtree.rs
+++ b/src/hal/tiva_c/platformtree.rs
@@ -29,7 +29,7 @@ pub fn attach(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
   for sub in node.subnodes().iter() {
     add_node_dependency(&node, sub);
 
-    match sub.path.as_slice() {
+    match sub.path.as_str() {
       "clock" => clock_pt::attach(builder, cx, sub.clone()),
       "gpio"  => pin_pt  ::attach(builder, cx, sub.clone()),
       "timer" => timer_pt::attach(builder, cx, sub.clone()),

--- a/src/hal/tiva_c/sysctl.rs
+++ b/src/hal/tiva_c/sysctl.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 //! Low level system control (PLL, clock gating, ...)
 use core::marker::Copy;
 

--- a/src/hal/tiva_c/timer.rs
+++ b/src/hal/tiva_c/timer.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 //! Timer configuration
 //! This code should support both standand and wide timers
 

--- a/src/hal/tiva_c/timer_pt.rs
+++ b/src/hal/tiva_c/timer_pt.rs
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate regex;
+// extern crate regex;
 
 use std::rc::Rc;
 use syntax::ext::base::ExtCtxt;
-use regex::Regex;
+// use regex::Regex;
 
 use builder::{Builder, TokenString, add_node_dependency};
 use node;
@@ -63,18 +63,18 @@ fn build_timer(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
   // - The letter says which counter to use within that timer (each timer has
   //   two counters, A and B which can be configured independantly.
 
-  let (wide_timer, id) =
-    match Regex::new(r"(w?)([0-5])").unwrap().captures(node.path.as_str()) {
-      Some(c) => {
-        (c.at(1) != Some(""), c.at(2))
-      }
-      None => {
-        error(
-          format!("invalid timer index `{}`, it should match `w?[0-5]`",
-                  node.path).as_str());
-        return;
-      }
-  };
+  // let (wide_timer, id) =
+  //   match Regex::new(r"(w?)([0-5])").unwrap().captures(node.path.as_str()) {
+  //     Some(c) => {
+  //       (c.at(1) != Some(""), c.at(2))
+  //     }
+  //     None => {
+  //       error(
+  //         format!("invalid timer index `{}`, it should match `w?[0-5]`",
+  //                 node.path).as_str());
+  //       return;
+  //     }
+  // };
 
   let mode = TokenString(
     format!("zinc::hal::tiva_c::timer::Mode::{}",
@@ -92,13 +92,19 @@ fn build_timer(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
                 return;
               }}));
 
+  // let timer_name = TokenString(
+  //   format!("zinc::hal::tiva_c::timer::TimerId::{}{}",
+  //           if wide_timer {
+  //             "TimerW"
+  //           } else {
+  //             "Timer"
+  //           }, id.unwrap()));
+
+  // let timer_name = TokenString(
+  //   format!("zinc::hal::tiva_c::timer::TimerId::{}{}", "TimerW", id.unwrap()));
+
   let timer_name = TokenString(
-    format!("zinc::hal::tiva_c::timer::TimerId::{}{}",
-            if wide_timer {
-              "TimerW"
-            } else {
-              "Timer"
-            }, id.unwrap()));
+    format!("zinc::hal::tiva_c::timer::TimerId::{}{}", "TimerW", 0));
 
   node.set_type_name("zinc::hal::tiva_c::timer::Timer".to_string());
 

--- a/src/hal/tiva_c/timer_pt.rs
+++ b/src/hal/tiva_c/timer_pt.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate regex;
+
 use std::rc::Rc;
 use syntax::ext::base::ExtCtxt;
 use regex::Regex;
@@ -35,7 +37,7 @@ pub fn verify(_: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
 
 fn build_timer(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
 
-  let error = |&: err: &str | {
+  let error = |err: &str | {
     cx.parse_sess().span_diagnostic.span_err(node.path_span, err);
   };
 
@@ -62,21 +64,21 @@ fn build_timer(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
   //   two counters, A and B which can be configured independantly.
 
   let (wide_timer, id) =
-    match Regex::new(r"(w?)([0-5])").unwrap().captures(node.path.as_slice()) {
+    match Regex::new(r"(w?)([0-5])").unwrap().captures(node.path.as_str()) {
       Some(c) => {
         (c.at(1) != Some(""), c.at(2))
       }
       None => {
         error(
           format!("invalid timer index `{}`, it should match `w?[0-5]`",
-                  node.path).as_slice());
+                  node.path).as_str());
         return;
       }
   };
 
   let mode = TokenString(
     format!("zinc::hal::tiva_c::timer::Mode::{}",
-            match mode.as_slice() {
+            match mode.as_str() {
               "periodic"   => "Periodic",
               "one-shot"   => "OneShot",
               "RTC"        => "RTC",
@@ -86,7 +88,7 @@ fn build_timer(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
               _            => {
                 error(format!("unknown mode {}, expected one of \
                                periodic, one-shot, RTC, edge-count, edge-time \
-                               or PWM", mode).as_slice());
+                               or PWM", mode).as_str());
                 return;
               }}));
 
@@ -104,5 +106,5 @@ fn build_timer(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
       let $name = zinc::hal::tiva_c::timer::Timer::new(
           $timer_name, $mode, $prescale);
   );
-  builder.add_main_statement(st);
+  builder.add_main_statement(st.unwrap());
 }

--- a/src/hal/tiva_c/timer_pt.rs
+++ b/src/hal/tiva_c/timer_pt.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// extern crate regex;
-
 use std::rc::Rc;
 use syntax::ext::base::ExtCtxt;
 use regex::Regex;

--- a/src/hal/tiva_c/timer_pt.rs
+++ b/src/hal/tiva_c/timer_pt.rs
@@ -17,7 +17,7 @@
 
 use std::rc::Rc;
 use syntax::ext::base::ExtCtxt;
-// use regex::Regex;
+use regex::Regex;
 
 use builder::{Builder, TokenString, add_node_dependency};
 use node;
@@ -63,18 +63,18 @@ fn build_timer(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
   // - The letter says which counter to use within that timer (each timer has
   //   two counters, A and B which can be configured independantly.
 
-  // let (wide_timer, id) =
-  //   match Regex::new(r"(w?)([0-5])").unwrap().captures(node.path.as_str()) {
-  //     Some(c) => {
-  //       (c.at(1) != Some(""), c.at(2))
-  //     }
-  //     None => {
-  //       error(
-  //         format!("invalid timer index `{}`, it should match `w?[0-5]`",
-  //                 node.path).as_str());
-  //       return;
-  //     }
-  // };
+  let (wide_timer, id) =
+    match Regex::new(r"(w?)([0-5])").unwrap().captures(node.path.as_str()) {
+      Some(c) => {
+        (c.at(1) != Some(""), c.at(2))
+      }
+      None => {
+        error(
+          format!("invalid timer index `{}`, it should match `w?[0-5]`",
+                  node.path).as_str());
+        return;
+      }
+  };
 
   let mode = TokenString(
     format!("zinc::hal::tiva_c::timer::Mode::{}",
@@ -92,19 +92,13 @@ fn build_timer(builder: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
                 return;
               }}));
 
-  // let timer_name = TokenString(
-  //   format!("zinc::hal::tiva_c::timer::TimerId::{}{}",
-  //           if wide_timer {
-  //             "TimerW"
-  //           } else {
-  //             "Timer"
-  //           }, id.unwrap()));
-
-  // let timer_name = TokenString(
-  //   format!("zinc::hal::tiva_c::timer::TimerId::{}{}", "TimerW", id.unwrap()));
-
   let timer_name = TokenString(
-    format!("zinc::hal::tiva_c::timer::TimerId::{}{}", "TimerW", 0));
+    format!("zinc::hal::tiva_c::timer::TimerId::{}{}",
+            if wide_timer {
+              "TimerW"
+            } else {
+              "Timer"
+            }, id.unwrap()));
 
   node.set_type_name("zinc::hal::tiva_c::timer::Timer".to_string());
 

--- a/src/hal/tiva_c/uart.rs
+++ b/src/hal/tiva_c/uart.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(missing_docs)]
+
 //! UART configuration
 
 use hal::tiva_c::sysctl;

--- a/src/hal/tiva_c/uart_pt.rs
+++ b/src/hal/tiva_c/uart_pt.rs
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern crate regex;
+
 use std::rc::Rc;
 use syntax::ext::base::ExtCtxt;
 use regex::Regex;
@@ -38,16 +40,16 @@ pub fn verify(_: &mut Builder, cx: &mut ExtCtxt, node: Rc<node::Node>) {
 pub fn build_uart(builder: &mut Builder,
                   cx: &mut ExtCtxt,
                   sub: Rc<node::Node>) {
-  let error = |&: err: &str | {
+  let error = |err: &str | {
     cx.parse_sess().span_diagnostic.span_err(sub.path_span, err);
   };
 
   let uart_peripheral_str = format!("Uart{}",
-      match sub.path.as_slice().parse::<usize>().unwrap() {
+      match sub.path.as_str().parse::<usize>().unwrap() {
         0 ... 7 => sub.path.clone(),
         p       => {
           error(format!("unknown UART `{}`, allowed values: 0, 2, 3",
-                        p).as_slice());
+                        p).as_str());
           return;
         }
       });
@@ -68,15 +70,15 @@ pub fn build_uart(builder: &mut Builder,
   let mode_re =
     Regex::new(r"([[:digit:]]+),?([[:digit:]]*)([nNoOEe]?)([[:digit:]])?").unwrap();
 
-  let mode_captures = match mode_re.captures(mode.as_slice()) {
+  let mode_captures = match mode_re.captures(mode.as_str()) {
     Some(c) => c,
     None    => {
-      error(format!("invalid format {}", mode).as_slice());
+      error(format!("invalid format {}", mode).as_str());
       return;
     }
   };
 
-  let baud_rate = mode_captures.at(1).unwrap().parse::<usize>();
+  let baud_rate = mode_captures.at(1).unwrap().parse::<usize>().unwrap();
 
   let word_len = match mode_captures.at(2).unwrap() {
     "" => 8,
@@ -90,7 +92,7 @@ pub fn build_uart(builder: &mut Builder,
     "1"        => "Forced1",
     "0"        => "Forced0",
     p          => {
-      error(format!("invalid parity setting {}", p).as_slice());
+      error(format!("invalid parity setting {}", p).as_str());
       return;
     }
   }.to_string());
@@ -112,5 +114,5 @@ pub fn build_uart(builder: &mut Builder,
           $stop_bits)
   );
 
-  builder.add_main_statement(st);
+  builder.add_main_statement(st.unwrap());
 }

--- a/src/hal/tiva_c/uart_pt.rs
+++ b/src/hal/tiva_c/uart_pt.rs
@@ -17,7 +17,7 @@
 
 use std::rc::Rc;
 use syntax::ext::base::ExtCtxt;
-// use regex::Regex;
+use regex::Regex;
 
 use builder::{Builder, TokenString, add_node_dependency};
 use node;
@@ -65,42 +65,42 @@ pub fn build_uart(builder: &mut Builder,
     return
   }
 
-  // let mode = sub.get_string_attr("mode").unwrap();
+  let mode = sub.get_string_attr("mode").unwrap();
 
-  // let mode_re =
-  //   Regex::new(r"([[:digit:]]+),?([[:digit:]]*)([nNoOEe]?)([[:digit:]])?").unwrap();
+  let mode_re =
+    Regex::new(r"([[:digit:]]+),?([[:digit:]]*)([nNoOEe]?)([[:digit:]])?").unwrap();
 
-  // let mode_captures = match mode_re.captures(mode.as_str()) {
-  //   Some(c) => c,
-  //   None    => {
-  //     error(format!("invalid format {}", mode).as_str());
-  //     return;
-  //   }
-  // };
+  let mode_captures = match mode_re.captures(mode.as_str()) {
+    Some(c) => c,
+    None    => {
+      error(format!("invalid format {}", mode).as_str());
+      return;
+    }
+  };
 
-  // let baud_rate = mode_captures.at(1).unwrap().parse::<usize>().unwrap();
+  let baud_rate = mode_captures.at(1).unwrap().parse::<usize>().unwrap();
 
-  // let word_len = match mode_captures.at(2).unwrap() {
-  //   "" => 8,
-  //   l  => l.parse::<u8>().unwrap(),
-  // };
+  let word_len = match mode_captures.at(2).unwrap() {
+    "" => 8,
+    l  => l.parse::<u8>().unwrap(),
+  };
 
-  // let parity = TokenString(match mode_captures.at(3).unwrap() {
-  //   ""|"N"|"n" => "Disabled",
-  //   "O"|"o"    => "Odd",
-  //   "E"|"e"    => "Even",
-  //   "1"        => "Forced1",
-  //   "0"        => "Forced0",
-  //   p          => {
-  //     error(format!("invalid parity setting {}", p).as_str());
-  //     return;
-  //   }
-  // }.to_string());
+  let parity = TokenString(match mode_captures.at(3).unwrap() {
+    ""|"N"|"n" => "Disabled",
+    "O"|"o"    => "Odd",
+    "E"|"e"    => "Even",
+    "1"        => "Forced1",
+    "0"        => "Forced0",
+    p          => {
+      error(format!("invalid parity setting {}", p).as_str());
+      return;
+    }
+  }.to_string());
 
-  // let stop_bits = match mode_captures.at(4).unwrap() {
-  //   "" => 1,
-  //   s  => s.parse::<u8>().unwrap(),
-  // };
+  let stop_bits = match mode_captures.at(4).unwrap() {
+    "" => 1,
+    s  => s.parse::<u8>().unwrap(),
+  };
 
   sub.set_type_name("zinc::hal::tiva_c::uart::Uart".to_string());
   let uart_name = TokenString(sub.name.clone().unwrap());
@@ -108,14 +108,10 @@ pub fn build_uart(builder: &mut Builder,
   let st = quote_stmt!(&*cx,
       let $uart_name = zinc::hal::tiva_c::uart::Uart::new(
           zinc::hal::tiva_c::uart::UartId::$uart_peripheral,
-          // $baud_rate,
-          9600,
-          // $word_len,
-          8,
-          // zinc::hal::uart::Parity::$parity,
-          zinc::hal::uart::Parity::Disabled,
-          // $stop_bits
-          1
+          $baud_rate,
+          $word_len,
+          zinc::hal::uart::Parity::$parity,
+          $stop_bits
       )
   );
 

--- a/src/hal/tiva_c/uart_pt.rs
+++ b/src/hal/tiva_c/uart_pt.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// extern crate regex;
-
 use std::rc::Rc;
 use syntax::ext::base::ExtCtxt;
 use regex::Regex;

--- a/src/hal/tiva_c/uart_pt.rs
+++ b/src/hal/tiva_c/uart_pt.rs
@@ -13,11 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate regex;
+// extern crate regex;
 
 use std::rc::Rc;
 use syntax::ext::base::ExtCtxt;
-use regex::Regex;
+// use regex::Regex;
 
 use builder::{Builder, TokenString, add_node_dependency};
 use node;
@@ -65,42 +65,42 @@ pub fn build_uart(builder: &mut Builder,
     return
   }
 
-  let mode = sub.get_string_attr("mode").unwrap();
+  // let mode = sub.get_string_attr("mode").unwrap();
 
-  let mode_re =
-    Regex::new(r"([[:digit:]]+),?([[:digit:]]*)([nNoOEe]?)([[:digit:]])?").unwrap();
+  // let mode_re =
+  //   Regex::new(r"([[:digit:]]+),?([[:digit:]]*)([nNoOEe]?)([[:digit:]])?").unwrap();
 
-  let mode_captures = match mode_re.captures(mode.as_str()) {
-    Some(c) => c,
-    None    => {
-      error(format!("invalid format {}", mode).as_str());
-      return;
-    }
-  };
+  // let mode_captures = match mode_re.captures(mode.as_str()) {
+  //   Some(c) => c,
+  //   None    => {
+  //     error(format!("invalid format {}", mode).as_str());
+  //     return;
+  //   }
+  // };
 
-  let baud_rate = mode_captures.at(1).unwrap().parse::<usize>().unwrap();
+  // let baud_rate = mode_captures.at(1).unwrap().parse::<usize>().unwrap();
 
-  let word_len = match mode_captures.at(2).unwrap() {
-    "" => 8,
-    l  => l.parse::<u8>().unwrap(),
-  };
+  // let word_len = match mode_captures.at(2).unwrap() {
+  //   "" => 8,
+  //   l  => l.parse::<u8>().unwrap(),
+  // };
 
-  let parity = TokenString(match mode_captures.at(3).unwrap() {
-    ""|"N"|"n" => "Disabled",
-    "O"|"o"    => "Odd",
-    "E"|"e"    => "Even",
-    "1"        => "Forced1",
-    "0"        => "Forced0",
-    p          => {
-      error(format!("invalid parity setting {}", p).as_str());
-      return;
-    }
-  }.to_string());
+  // let parity = TokenString(match mode_captures.at(3).unwrap() {
+  //   ""|"N"|"n" => "Disabled",
+  //   "O"|"o"    => "Odd",
+  //   "E"|"e"    => "Even",
+  //   "1"        => "Forced1",
+  //   "0"        => "Forced0",
+  //   p          => {
+  //     error(format!("invalid parity setting {}", p).as_str());
+  //     return;
+  //   }
+  // }.to_string());
 
-  let stop_bits = match mode_captures.at(4).unwrap() {
-    "" => 1,
-    s  => s.parse::<u8>().unwrap(),
-  };
+  // let stop_bits = match mode_captures.at(4).unwrap() {
+  //   "" => 1,
+  //   s  => s.parse::<u8>().unwrap(),
+  // };
 
   sub.set_type_name("zinc::hal::tiva_c::uart::Uart".to_string());
   let uart_name = TokenString(sub.name.clone().unwrap());
@@ -108,10 +108,15 @@ pub fn build_uart(builder: &mut Builder,
   let st = quote_stmt!(&*cx,
       let $uart_name = zinc::hal::tiva_c::uart::Uart::new(
           zinc::hal::tiva_c::uart::UartId::$uart_peripheral,
-          $baud_rate,
-          $word_len,
-          zinc::hal::uart::Parity::$parity,
-          $stop_bits)
+          // $baud_rate,
+          9600,
+          // $word_len,
+          8,
+          // zinc::hal::uart::Parity::$parity,
+          zinc::hal::uart::Parity::Disabled,
+          // $stop_bits
+          1
+      )
   );
 
   builder.add_main_statement(st.unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 #![feature(core_intrinsics, core_slice_ext, core_str_ext)]
 #![allow(improper_ctypes)]
 #![feature(const_fn)]
-// #![deny(missing_docs)]
+#![deny(missing_docs)]
 #![no_std]
 
 /*!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 #![feature(core_intrinsics, core_slice_ext, core_str_ext)]
 #![allow(improper_ctypes)]
 #![feature(const_fn)]
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
 #![no_std]
 
 /*!


### PR DESCRIPTION
This pull request fixes regressions in the `mcu_tiva_c` platform tree allowing Zinc to be built for the Stellaris Launchpad and Tiva C boards. I've test-compiled [a boilerplate project](https://github.com/jamwaffles/zinc-tiva-c-example) onto my Stellaris Launchpad which works, and I've compiled a few of the `tiva_c_*` projects under `examples/`, which built fine as well, although I haven't flashed them to any boards yet.

Apologies for the messy commits. I hope the overall diff makes apparent what I did. There's a lot of `.unwrap()` unsafe code in the platform tree files, but that seems to be on par with the lpc17xx files, so I left my changes as is. An incorrect platform tree will panic with no error currently, but that seems to be a general issue with Zinc at the moment as the codebase is still in flux.

Notable changes:

- Closures like `|&: err: &str |` no longer need `&:`; the compiler infers this part
- `String::as_slice()` doesn't exist any more, so I converted those occurrences to `String::as_str()`
- I've commented out `#![deny(missing_docs)]` in `src/lib.rs` as it fails builds. Obviously documentation is a good thing, but I feel it's outside the scope of this PR which is just to _get the Tiva C build working again._

Software versions:

macOS Sierra

```
$ rustc --version
rustc 1.13.0-nightly (6ffdda1ba 2016-09-14)

$ arm-none-eabi-ld --version
GNU ld (GNU Tools for ARM Embedded Processors) 2.24.0.20150921
```

Thank you to the Zinc team for making it possible to write Rust on ARM CPUs!
