### PR TITLE
Tiva C SPI support

### DIFF
--- a/src/hal/tiva_c/mod.rs
+++ b/src/hal/tiva_c/mod.rs
@@ -20,5 +20,6 @@ pub mod sysctl;
 pub mod pin;
 pub mod timer;
 pub mod uart;
+pub mod spi;
 
 #[path="../../util/ioreg.rs"] mod util;

--- a/src/hal/tiva_c/mod.rs
+++ b/src/hal/tiva_c/mod.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 //! HAL for TI TM4C123GH6PM
-//! This MCU is used on the TI stellaris and Tiva C launchpad development boards.
+/// This MCU is used on the TI stellaris and Tiva C launchpad development boards.
 
 pub mod sysctl;
 pub mod pin;

--- a/src/hal/tiva_c/spi.rs
+++ b/src/hal/tiva_c/spi.rs
@@ -15,7 +15,8 @@
 
 //! SPI configuration
 
-/// Enables SPI interface on any of the 4 SSI (Synchronous Serial Interface) modules in TM4C microcontrollers
+/// Enables SPI interface on any of the 4 SSI (Synchronous Serial Interface)
+/// modules in TM4C microcontrollers
 
 use core::intrinsics::abort;
 use hal::tiva_c::sysctl;
@@ -49,8 +50,9 @@ SPI configuration object
 
 Configuration object used when instantiating an SPI instance
 
-Note: The SPI GPIO pins must be set up correctly before using SPI. For example, for a master-only TX and CK config on SSI0,
-the platformtree section might look like the following (taken from a Tiva C configuration):
+Note: The SPI GPIO pins must be set up correctly before using SPI. For example,
+for a master-only TX and CK config on SSI0, the platformtree section might look
+like the following (taken from a Tiva C configuration):
 
 ```
 gpio {
@@ -190,8 +192,10 @@ impl Spi {
 
   /// Set SPI frequency
   ///
-  /// This function computes the divisor and exponent (for lack of a better name). These are stored in `ssicpsr.cpsdvsr` and `ssicr0.scr` respectively.
-  /// The clock rate formula (taken from the datasheet is) `ClockRate = SysClk / (CPSDVSR * (1 + SCR))` where SysClk is the system clock in Hz.
+  /// This function computes the divisor and exponent (for lack of a better name).
+  /// These are stored in `ssicpsr.cpsdvsr` and `ssicr0.scr` respectively.
+  /// The clock rate formula (taken from the datasheet is)
+  /// `ClockRate = SysClk / (CPSDVSR * (1 + SCR))` where SysClk is the system clock in Hz.
   fn set_frequency(&self, freq: u32) {
     let sysclk = sysctl::clock::sysclk_get() as u32;
 
@@ -201,7 +205,8 @@ impl Spi {
       let prescale_hz = sysclk / divisor;
 
       // Calculate exponent
-      // TODO(jamwaffles) The below line crashes my Tiva, presumably because floating point is broken?
+      // TODO(jamwaffles) The below line crashes my Tiva,
+      // presumably because floating point is broken?
       // let scr = ((prescale_hz as f32 / freq as f32) + 0.5f32) as u32;
 
       let scr = prescale_hz / freq;
@@ -218,12 +223,14 @@ impl Spi {
       divisor += 2;
     }
 
-    // TODO(jamwaffles): Return a Result from here as well as the calling configure method
+    // TODO(jamwaffles): Return a Result from here as well as the calling
+    // configure method
     unsafe { abort() };
   }
 
   /// Wait for SSI TX FIFO to be ready
-  /// This checks the busy flag (0 = not busy) and the "transmit FIFO not full" flag (1 = not full)
+  /// This checks the busy flag (0 = not busy) and the "transmit FIFO not full"
+  /// flag (1 = not full)
   fn writeable(&self) -> bool {
     !self.regs.ssisr.bsy() && self.regs.ssisr.tnf()
   }
@@ -257,24 +264,38 @@ pub mod reg {
   ioregs!(Ssi = {
     /// SSI control register 0
     0x000 => reg16 ssicr0 {
-      0..3 => dss: rw,    //= Data size select, 0x7 = 8 bits, see datasheet page 970 for other values
+      0..3 => dss: rw,    //= Data size select, 0x7 = 8 bits, see datasheet page
+                          //= 970 for other values
       4..5 => frf: rw,    //= Frame format, 0 = SPI 1 = TI SSF 2 Microwire
-      6    => spo: rw,    //= SSI polarity, 0 = steady staate low on SSInCLK 1 = steady state high
+      6    => spo: rw,    //= SSI polarity, 0 = steady staate low on
+                          //= SSInCLK 1 = steady state high
       7    => sph: rw,    //= SSI clock phase, 1 = first edge 0 = second edge
-      15..8 => scr: rw,   //= SSI clock rate, calculated from formula `SysClk / (CPSDVSR * (1 + SCR))`
+      15..8 => scr: rw,   //= SSI clock rate, calculated from formula
+                          //= `SysClk / (CPSDVSR * (1 + SCR))`
     },
 
     /// SSI control register 1
     0x004 => reg16 ssicr1 {
       0 => lbm: rw,       //= Loopback enable, 1 = enabled 0 = normal operation
-      1 => sse: rw,       //= Serial port enable 1 = enabled 0 = disabled. Must be cleared before SSI can be configured
+      1 => sse: rw,       //= Serial port enable 1 = enabled 0 = disabled.
+                          //= Must be cleared before SSI can be configured
       2 => ms: rw,        //= Master/slave select 0 = master 1 = slave
       4 => eot: rw,       //= End of transmission. Not sure what this is
     },
 
     /// SSI send/receive register
-    /// When the SSIDR register is read, the entry in the receive FIFO that is pointed to by the current FIFO read pointer is accessed. When a data value is removed by the SSI receive logic from the incoming data frame, it is placed into the entry in the receive FIFO pointed to by the current FIFO write pointer.
-    /// When the SSIDR register is written to, the entry in the transmit FIFO that is pointed to by the write pointer is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. Each data value is loaded into the transmit serial shifter, then serially shifted out onto the SSInTx pin at the programmed bit rate.
+    ///
+    /// When the SSIDR register is read, the entry in the receive FIFO that is
+    /// pointed to by the current FIFO read pointer is accessed. When a data
+    /// value is removed by the SSI receive logic from the incoming data frame,
+    /// it is placed into the entry in the receive FIFO pointed to by the
+    /// current FIFO write pointer.
+    ///
+    /// When the SSIDR register is written to, the entry in the transmit FIFO
+    /// that is pointed to by the write pointer is written to. Data values are
+    /// removed from the transmit FIFO one value at a time by the transmit
+    /// logic. Each data value is loaded into the transmit serial shifter, then
+    /// serially shifted out onto the SSInTx pin at the programmed bit rate.
     /// See page 973 in datasheet for more details
     0x008 => reg16 ssidr {
       0..15 => data: rw   //= Receive/transmit data
@@ -286,7 +307,8 @@ pub mod reg {
       1 => tnf: ro,       //= TX FIFO full 1 = not full 0 = full
       2 => rne: ro,       //= RX FIFO 1 = not empty 0 = empty
       3 => rff: ro,       //= RX FIFO full 0 = not full 1 = full
-      4 => bsy: ro,       //= SSI busy 0 = idle, can send data 1 = transmitting, can't send data yet
+      4 => bsy: ro,       //= SSI busy 0 = idle, can send data 1 = transmitting,
+                          //= can't send data yet
     },
 
     /// SSI clock prescale register
@@ -296,7 +318,8 @@ pub mod reg {
 
     /// SSI clock source configuration
     0xfc8 => reg16 ssicc {
-      0..3 => cs: rw,     //= SSI baud clock source, 0x0 = system clock, 0x5 = PIOSC
+      0..3 => cs: rw,     //= SSI baud clock source, 0x0 = system clock,
+                          //= 0x5 = PIOSC
     },
   });
 

--- a/src/hal/tiva_c/spi.rs
+++ b/src/hal/tiva_c/spi.rs
@@ -1,0 +1,181 @@
+// Zinc, the bare metal stack for rust.
+// Copyright 2014 Lionel Flandrin <lionel@svkt.org>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! SPI module
+//! Enables SPI interface on any of the 4 SSI (Synchronous Serial Interface) modules in TM4C microcontrollers
+
+use hal::tiva_c::sysctl;
+use util::support::get_reg_ref;
+
+#[path="../../util/ioreg.rs"]
+#[macro_use] mod ioreg;
+#[path="../../util/wait_for.rs"]
+#[macro_use] mod wait_for;
+
+/// Clock source for SSI module
+/// TODO(jamwaffles) Implement the ability to choose a clock source
+// pub enum ClockSource {
+//   /// System configured clock source
+//   System = 0x0,
+
+//   /// The Precision Internal Oscillator @16MHz
+//   PIOSC  = 0x5,
+// }
+
+/// There are 4 SSI instances an SPI interface can use
+#[allow(missing_docs)]
+#[derive(Clone, Copy)]
+pub enum SpiId {
+  Spi0,
+  Spi1,
+  Spi2,
+  Spi3,
+}
+
+/// Structure describing a single SPI interface
+#[derive(Clone, Copy)]
+pub struct Spi {
+  /// SSI registers
+  regs: &'static reg::Ssi,
+}
+
+impl Spi {
+  /// Create and setup a UART.
+  pub fn new(id: SpiId) -> Spi {
+
+    let (periph, regs) = match id {
+      SpiId::Spi0 => (sysctl::periph::ssi::SSI_0, reg::SSI_0),
+      SpiId::Spi1 => (sysctl::periph::ssi::SSI_1, reg::SSI_1),
+      SpiId::Spi2 => (sysctl::periph::ssi::SSI_2, reg::SSI_2),
+      SpiId::Spi3 => (sysctl::periph::ssi::SSI_3, reg::SSI_3),
+    };
+
+    let spi = Spi { regs: get_reg_ref(regs) };
+
+    periph.ensure_enabled();
+
+    spi.configure();
+
+    spi
+  }
+
+  /// Configure the SSI into SPI mode. Currently hard coded at 3.2MHz for 16MHz PIOSC
+  fn configure(&self) {
+    let sysclk = sysctl::clock::sysclk_get();
+
+    self.regs.ssicr1
+      .set_sse(false)
+      .set_ms(false)
+      .set_lbm(false);
+
+    // 3.2MHz fixed bitrate for 16MHz crystal and 80MHz PLL
+    self.regs.ssicpsr
+      .set_cpsdvsr(25);
+
+    self.regs.ssicr0
+      .set_scr(0)
+      .set_sph(false)
+      .set_spo(false)
+      .set_frf(0)     // SPI mode
+      .set_dss(0x7);  // 8 bit frames
+
+    // Turn on SSI now that we've configured it
+    self.regs.ssicr1
+      .set_sse(true);
+  }
+
+  /// Wait for SSI TX FIFO to be ready
+  /// This checks the busy flag (0 = not busy) and the "transmit FIFO not full" flag (1 = not full)
+  fn writeable(&self) -> bool {
+    !self.regs.ssisr.bsy() && self.regs.ssisr.tnf()
+  }
+
+  /// Wait for SSI data buffer to be readable
+  fn readable(&self) -> bool {
+    !self.regs.ssisr.bsy()
+  }
+}
+
+impl ::hal::spi::Spi for Spi {
+  fn write(&self, value: u8) {
+    wait_for!(self.writeable());
+
+    self.regs.ssidr.set_data(value as u16);
+  }
+
+  fn read(&self) -> u8 {
+    wait_for!(self.readable());
+
+    self.regs.ssidr.data() as u8
+  }
+}
+
+#[allow(missing_docs)]
+pub mod reg {
+  //! SSI registers definition
+  use volatile_cell::VolatileCell;
+  use core::ops::Drop;
+
+  ioregs!(Ssi = {
+    /// SSI control register 0
+    0x000 => reg16 ssicr0 {
+      0..3 => dss: rw,    //= Data size select, 0x7 = 8 bits, see datasheet page 970 for other values
+      4..5 => frf: rw,    //= Frame format, 0 = SPI 1 = TI SSF 2 Microwire
+      6    => spo: rw,    //= SSI polarity, 0 = steady staate low on SSInCLK 1 = steady state high
+      7    => sph: rw,    //= SSI clock phase, 1 = first edge 0 = second edge
+      15..8 => scr: rw,   //= SSI clock rate, calculated from formula `SysClk / (CPSDVSR * (1 + SCR))`
+    },
+
+    /// SSI control register 1
+    0x004 => reg16 ssicr1 {
+      0 => lbm: rw,       //= Loopback enable, 1 = enabled 0 = normal operation
+      1 => sse: rw,       //= Serial port enable 1 = enabled 0 = disabled. Must be cleared before SSI can be configured
+      2 => ms: rw,        //= Master/slave select 0 = master 1 = slave
+      4 => eot: rw,       //= End of transmission. Not sure what this is
+    },
+
+    /// SSI send/receive register
+    /// When the SSIDR register is read, the entry in the receive FIFO that is pointed to by the current FIFO read pointer is accessed. When a data value is removed by the SSI receive logic from the incoming data frame, it is placed into the entry in the receive FIFO pointed to by the current FIFO write pointer.
+    /// When the SSIDR register is written to, the entry in the transmit FIFO that is pointed to by the write pointer is written to. Data values are removed from the transmit FIFO one value at a time by the transmit logic. Each data value is loaded into the transmit serial shifter, then serially shifted out onto the SSInTx pin at the programmed bit rate.
+    /// See page 973 in datasheet for more details
+    0x008 => reg16 ssidr {
+      0..15 => data: rw   //= Receive/transmit data
+    },
+
+    /// SSI status register
+    0x00c => reg16 ssisr {
+      0 => tfe: ro,       //= TX FIFO empty 1 = empty 0 = not empty
+      1 => tnf: ro,       //= TX FIFO full 1 = not full 0 = full
+      2 => rne: ro,       //= RX FIFO 1 = not empty 0 = empty
+      3 => rff: ro,       //= RX FIFO full 0 = not full 1 = full
+      4 => bsy: ro,       //= SSI busy 0 = idle, can send data 1 = transmitting, can't send data yet
+    },
+
+    /// SSI clock prescale register
+    0x010 => reg16 ssicpsr {
+      0..7 => cpsdvsr: rw //= SSI clock prescale divisor, 2 – 254 inclusive
+    },
+
+    /// SSI clock source configuration
+    0xfc8 => reg16 ssicc {
+      0..3 => cs: rw,     //= SSI baud clock source, 0x0 = system clock, 0x5 = PIOSC
+    },
+  });
+
+  pub const SSI_0: *const Ssi = 0x40008000 as *const Ssi;
+  pub const SSI_1: *const Ssi = 0x40009000 as *const Ssi;
+  pub const SSI_2: *const Ssi = 0x4000A000 as *const Ssi;
+  pub const SSI_3: *const Ssi = 0x4000B000 as *const Ssi;
+}

--- a/src/hal/tiva_c/spi.rs
+++ b/src/hal/tiva_c/spi.rs
@@ -165,7 +165,7 @@ impl Spi {
     spi
   }
 
-  /// Configure the SSI into SPI mode. Currently hard coded at 3.2MHz for 16MHz PIOSC
+  /// Configure the SSI into SPI mode
   fn configure(&self, config: SpiConf) {
     // Disable peripheral so we can configure it
     self.regs.ssicr1.set_sse(false);

--- a/src/hal/tiva_c/spi.rs
+++ b/src/hal/tiva_c/spi.rs
@@ -322,6 +322,7 @@ pub mod reg {
     },
   });
 
+  // TODO(jamwaffles): Change to placement ioregs
   pub const SSI_0: *const Ssi = 0x40008000 as *const Ssi;
   pub const SSI_1: *const Ssi = 0x40009000 as *const Ssi;
   pub const SSI_2: *const Ssi = 0x4000A000 as *const Ssi;

--- a/src/hal/tiva_c/spi.rs
+++ b/src/hal/tiva_c/spi.rs
@@ -201,7 +201,10 @@ impl Spi {
       let prescale_hz = sysclk / divisor;
 
       // Calculate exponent
-      let scr = ((prescale_hz as f32 / freq as f32) + 0.5f32) as u32;
+      // TODO(jamwaffles) The below line crashes my Tiva, presumably because floating point is broken?
+      // let scr = ((prescale_hz as f32 / freq as f32) + 0.5f32) as u32;
+
+      let scr = prescale_hz / freq;
 
       // Check we can support the divider
       if scr < 256 {

--- a/src/hal/tiva_c/spi.rs
+++ b/src/hal/tiva_c/spi.rs
@@ -193,21 +193,21 @@ impl Spi {
   /// This function computes the divisor and exponent (for lack of a better name). These are stored in `ssicpsr.cpsdvsr` and `ssicr0.scr` respectively.
   /// The clock rate formula (taken from the datasheet is) `ClockRate = SysClk / (CPSDVSR * (1 + SCR))` where SysClk is the system clock in Hz.
   fn set_frequency(&self, freq: u32) {
-    let sysclk = sysctl::clock::sysclk_get() as u16;
+    let sysclk = sysctl::clock::sysclk_get() as u32;
 
-    let mut divisor: u16 = 2;
+    let mut divisor: u32 = 2;
 
     while divisor <= 254 {
-      let prescale_hz: u16 = sysclk / divisor;
+      let prescale_hz = sysclk / divisor;
 
       // Calculate exponent
-      let scr: u16 = ((prescale_hz as f32 / freq as f32) + 0.5f32) as u16;
+      let scr = ((prescale_hz as f32 / freq as f32) + 0.5f32) as u32;
 
       // Check we can support the divider
       if scr < 256 {
-        self.regs.ssicpsr.set_cpsdvsr(divisor);
+        self.regs.ssicpsr.set_cpsdvsr(divisor as u16);
 
-        self.regs.ssicr0.set_scr(scr - 1);
+        self.regs.ssicr0.set_scr((scr - 1) as u16);
 
         return
       }

--- a/src/hal/tiva_c/spi.rs
+++ b/src/hal/tiva_c/spi.rs
@@ -214,7 +214,6 @@ impl Spi {
       // Check we can support the divider
       if scr < 256 {
         self.regs.ssicpsr.set_cpsdvsr(divisor as u16);
-
         self.regs.ssicr0.set_scr((scr - 1) as u16);
 
         return

--- a/src/hal/tiva_c/sysctl.rs
+++ b/src/hal/tiva_c/sysctl.rs
@@ -415,6 +415,20 @@ pub mod periph {
     pub const UART_7: super::PeripheralClock =
       super::PeripheralClock { class: CLASS, id: 7 };
   }
+
+  pub mod ssi {
+    //! SSI peripherals instances
+    const CLASS: u8 = 0x1c / 4;
+
+    pub const SSI_0: super::PeripheralClock =
+      super::PeripheralClock { class: CLASS, id: 0 };
+    pub const SSI_1: super::PeripheralClock =
+      super::PeripheralClock { class: CLASS, id: 1 };
+    pub const SSI_2: super::PeripheralClock =
+      super::PeripheralClock { class: CLASS, id: 2 };
+    pub const SSI_3: super::PeripheralClock =
+      super::PeripheralClock { class: CLASS, id: 3 };
+  }
 }
 
 pub mod reg {


### PR DESCRIPTION
This PR adds reasonably basic SPI support for the Tiva C HAL. It allows choosing one of 4 SSI peripherals to use for SPI transmission as well as the desired frequency to operate at. Other options should be pretty easy to add in the future.

I've made a pretty good stab at documenting this module; `cargo doc --features=mcu_tiva_c` produces some docs, even with a complete example. I'd love to see an awesome set of documentation for Zinc, so this is my contribution to the start of it :).