### PR TITLE
tiva_c docs should ignore only actual pin instantiations

### DIFF
--- a/src/hal/tiva_c/pin.rs
+++ b/src/hal/tiva_c/pin.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(missing_docs)]
-
 //! Pin configuration
 //! Allows GPIO configuration
 //! Pin muxing not implemented yet.

--- a/src/hal/tiva_c/pin.rs
+++ b/src/hal/tiva_c/pin.rs
@@ -216,10 +216,17 @@ pub mod reg {
     }
   });
 
-  pub const PORT_A: *const Port = 0x40004000 as *const Port;
-  pub const PORT_B: *const Port = 0x40005000 as *const Port;
-  pub const PORT_C: *const Port = 0x40006000 as *const Port;
-  pub const PORT_D: *const Port = 0x40007000 as *const Port;
-  pub const PORT_E: *const Port = 0x40024000 as *const Port;
-  pub const PORT_F: *const Port = 0x40025000 as *const Port;
+  #[allow(missing_docs)]
+  mod instances {
+    use super::*;
+
+    pub const PORT_A: *const Port = 0x40004000 as *const Port;
+    pub const PORT_B: *const Port = 0x40005000 as *const Port;
+    pub const PORT_C: *const Port = 0x40006000 as *const Port;
+    pub const PORT_D: *const Port = 0x40007000 as *const Port;
+    pub const PORT_E: *const Port = 0x40024000 as *const Port;
+    pub const PORT_F: *const Port = 0x40025000 as *const Port;
+  }
+
+  pub use self::instances::*;
 }

--- a/src/hal/tiva_c/sysctl.rs
+++ b/src/hal/tiva_c/sysctl.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(missing_docs)]
-
 //! Low level system control (PLL, clock gating, ...)
 use core::marker::Copy;
 

--- a/src/hal/tiva_c/sysctl.rs
+++ b/src/hal/tiva_c/sysctl.rs
@@ -339,6 +339,7 @@ pub mod periph {
     }
   }
 
+  #[allow(missing_docs)]
   pub mod gpio {
     //! GPIO system control peripherals. Split into ports of 8 GPIO each.
 
@@ -358,6 +359,7 @@ pub mod periph {
       super::PeripheralClock { class: CLASS, id: 5 };
   }
 
+  #[allow(missing_docs)]
   pub mod timer {
     //! Timer system control peripherals. Each timer has two independent
     //! counters (A and B).
@@ -392,6 +394,7 @@ pub mod periph {
       super::PeripheralClock { class: TIMER_W_CLASS, id: 5 };
   }
 
+  #[allow(missing_docs)]
   pub mod uart {
     //! UART peripherals instances
     const CLASS: u8 = 0x18 / 4;
@@ -414,6 +417,7 @@ pub mod periph {
       super::PeripheralClock { class: CLASS, id: 7 };
   }
 
+  #[allow(missing_docs)]
   pub mod ssi {
     //! SSI peripherals instances
     const CLASS: u8 = 0x1c / 4;
@@ -491,5 +495,6 @@ pub mod reg {
     }
   });
 
+  #[allow(missing_docs)]
   pub const SYSCTL: *const SysCtl = 0x400FE000 as *const SysCtl;
 }

--- a/src/hal/tiva_c/timer.rs
+++ b/src/hal/tiva_c/timer.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(missing_docs)]
-
 //! Timer configuration
 //! This code should support both standand and wide timers
 

--- a/src/hal/tiva_c/timer.rs
+++ b/src/hal/tiva_c/timer.rs
@@ -221,17 +221,23 @@ pub mod reg {
     }
   });
 
-  pub const TIMER_0:   *const Timer = 0x40030000 as *const Timer;
-  pub const TIMER_1:   *const Timer = 0x40031000 as *const Timer;
-  pub const TIMER_2:   *const Timer = 0x40032000 as *const Timer;
-  pub const TIMER_3:   *const Timer = 0x40033000 as *const Timer;
-  pub const TIMER_4:   *const Timer = 0x40034000 as *const Timer;
-  pub const TIMER_5:   *const Timer = 0x40035000 as *const Timer;
+  #[allow(missing_docs)]
+  mod instances {
+    use super::*;
 
-  pub const TIMER_W_0: *const Timer = 0x40036000 as *const Timer;
-  pub const TIMER_W_1: *const Timer = 0x40037000 as *const Timer;
-  pub const TIMER_W_2: *const Timer = 0x4003C000 as *const Timer;
-  pub const TIMER_W_3: *const Timer = 0x4003D000 as *const Timer;
-  pub const TIMER_W_4: *const Timer = 0x4003E000 as *const Timer;
-  pub const TIMER_W_5: *const Timer = 0x4003F000 as *const Timer;
+    pub const TIMER_0:   *const Timer = 0x40030000 as *const Timer;
+    pub const TIMER_1:   *const Timer = 0x40031000 as *const Timer;
+    pub const TIMER_2:   *const Timer = 0x40032000 as *const Timer;
+    pub const TIMER_3:   *const Timer = 0x40033000 as *const Timer;
+    pub const TIMER_4:   *const Timer = 0x40034000 as *const Timer;
+    pub const TIMER_5:   *const Timer = 0x40035000 as *const Timer;
+
+    pub const TIMER_W_0: *const Timer = 0x40036000 as *const Timer;
+    pub const TIMER_W_1: *const Timer = 0x40037000 as *const Timer;
+    pub const TIMER_W_2: *const Timer = 0x4003C000 as *const Timer;
+    pub const TIMER_W_3: *const Timer = 0x4003D000 as *const Timer;
+    pub const TIMER_W_4: *const Timer = 0x4003E000 as *const Timer;
+    pub const TIMER_W_5: *const Timer = 0x4003F000 as *const Timer;
+  }
+  pub use self::instances::*;
 }

--- a/src/hal/tiva_c/uart.rs
+++ b/src/hal/tiva_c/uart.rs
@@ -189,12 +189,17 @@ pub mod reg {
     }
   });
 
-  pub const UART_0: *const Uart = 0x4000C000 as *const Uart;
-  pub const UART_1: *const Uart = 0x4000D000 as *const Uart;
-  pub const UART_2: *const Uart = 0x4000E000 as *const Uart;
-  pub const UART_3: *const Uart = 0x4000F000 as *const Uart;
-  pub const UART_4: *const Uart = 0x40010000 as *const Uart;
-  pub const UART_5: *const Uart = 0x40011000 as *const Uart;
-  pub const UART_6: *const Uart = 0x40012000 as *const Uart;
-  pub const UART_7: *const Uart = 0x40013000 as *const Uart;
+  #[allow(missing_docs)]
+  mod instances {
+    use super::*;
+    pub const UART_0: *const Uart = 0x4000C000 as *const Uart;
+    pub const UART_1: *const Uart = 0x4000D000 as *const Uart;
+    pub const UART_2: *const Uart = 0x4000E000 as *const Uart;
+    pub const UART_3: *const Uart = 0x4000F000 as *const Uart;
+    pub const UART_4: *const Uart = 0x40010000 as *const Uart;
+    pub const UART_5: *const Uart = 0x40011000 as *const Uart;
+    pub const UART_6: *const Uart = 0x40012000 as *const Uart;
+    pub const UART_7: *const Uart = 0x40013000 as *const Uart;
+  }
+  pub use self::instances::*;
 }

--- a/src/hal/tiva_c/uart.rs
+++ b/src/hal/tiva_c/uart.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(missing_docs)]
-
 //! UART configuration
 
 use hal::tiva_c::sysctl;


### PR DESCRIPTION
Fix #373 