### PR TITLE
volatile_cell: Add version for expectest dependency

### DIFF
--- a/volatile_cell/Cargo.toml
+++ b/volatile_cell/Cargo.toml
@@ -16,4 +16,5 @@ crate-type = ["rlib"]
 replayer = ["expectest"]
 
 [dependencies.expectest]
+version = "^0.6"
 optional = true


### PR DESCRIPTION
Fix #385